### PR TITLE
feat: 添加 Docker 支持

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+__pycache__
+*.pyc
+.git
+.gitignore
+.venv
+.ruff_cache
+.DS_Store
+logs
+config.toml
+dist
+build
+images
+*.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends --no-install-suggests \
+    chromium \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /tmp/* \
+    && useradd -m -s /bin/bash appuser \
+    && mkdir -p /app/logs \
+    && chown -R appuser:appuser /app
+
+USER appuser
+WORKDIR /app
+
+ENV CHROMIUM_BINARY=/usr/bin/chromium
+
+COPY --chown=appuser:appuser pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/home/appuser/.cache/uv,uid=1000,gid=1000 \
+    uv sync --frozen --no-dev --no-install-project
+
+COPY --chown=appuser:appuser *.py .
+COPY --chown=appuser:appuser captcha_model.onnx .
+COPY --chown=appuser:appuser answer/answer.json answer/
+COPY --chown=appuser:appuser config.example.toml .
+
+VOLUME ["/app/logs"]
+
+ENTRYPOINT ["uv", "run", "python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ python main.py # 或 uv run main.py
 | macOS arm64 | [WeBan-3.7.1-macos-arm64](https://github.com/hangone/WeBan/releases/latest/download/WeBan-3.7.1-macos-arm64) | [WeBan-3.7.1-macos-arm64-bundle](https://github.com/hangone/WeBan/releases/latest/download/WeBan-3.7.1-macos-arm64-bundle) |
 | macOS x64 | [WeBan-3.7.1-macos-x64](https://github.com/hangone/WeBan/releases/latest/download/WeBan-3.7.1-macos-x64) | [WeBan-3.7.1-macos-x64-bundle](https://github.com/hangone/WeBan/releases/latest/download/WeBan-3.7.1-macos-x64-bundle) |
 
+### Docker
+
+```bash
+docker run -it --rm -v $(pwd)/config.toml:/app/config.toml -v $(pwd)/logs:/app/logs hangyi/weban
+```
+
+首次使用先从 [config.example.toml](config.example.toml) 复制一份 `config.toml` 并填写账号信息。
+
 ## 配置说明
 
 软件使用 `config.toml` 配置文件（首次运行会自动从远程下载模板）。账号级配置可覆盖全局设置。


### PR DESCRIPTION
## Summary
- 基于 `ghcr.io/astral-sh/uv:python3.12-bookworm-slim` 构建，使用 uv 管理依赖
- 非 root 用户运行，预装 Chromium 支持 drissionpage
- 添加 `.dockerignore` 排除不必要文件

## 使用方式
```bash
docker run -it --rm \
  -v $(pwd)/config.toml:/app/config.toml \
  -v $(pwd)/logs:/app/logs \
  hangyi/weban
```