### PR TITLE
feat: remove Pillow dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,6 @@ jobs:
             --hidden-import loguru \
             --hidden-import numpy \
             --hidden-import cv2 \
-            --hidden-import PIL \
             --collect-submodules nodriver \
             main.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --hidden-import loguru \
     --hidden-import numpy \
     --hidden-import cv2 \
-    --hidden-import PIL \
     --collect-submodules nodriver \
     main.py
 

--- a/captcha.py
+++ b/captcha.py
@@ -18,7 +18,6 @@ import sys
 import random
 import threading
 import time
-from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -26,7 +25,6 @@ import cv2
 import numpy as np
 import requests
 import nodriver
-from PIL import Image
 
 # 腾讯验证码 SDK 地址
 TCAPTCHA_SDK_URL = "https://turing.captcha.qcloud.com/TJCaptcha.js"
@@ -531,16 +529,15 @@ class LoginCaptchaSolver:
         if not ocr:
             return None
         try:
-            img = Image.open(BytesIO(image)).convert("L")
-            arr = np.array(img, dtype=np.uint8)
+            arr = cv2.imdecode(np.frombuffer(image, np.uint8), cv2.IMREAD_GRAYSCALE)
             h, w = arr.shape
             seg_w = w // 4
 
             result = []
             for i in range(4):
                 char_img = arr[:, i * seg_w:(i + 1) * seg_w if i < 3 else w]
-                resized = np.array(Image.fromarray(char_img).resize(
-                    (cls._char_size, cls._char_size), Image.BILINEAR))
+                resized = cv2.resize(char_img, (cls._char_size, cls._char_size),
+                                     interpolation=cv2.INTER_LINEAR)
                 inp = (resized.astype(np.float32) / 255.0).reshape(
                     1, 1, cls._char_size, cls._char_size)
                 with cls._lock:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "loguru>=0.7.3",
     "numpy>=1.26.0",
     "opencv-python-headless>=4.8.0",
-    "pillow>=12.2.0",
     "pyaes>=1.6.1",
     "requests>=2.34.2",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ colorama==0.4.6 ; sys_platform == 'win32'
     # via loguru
 deprecated==1.3.1
     # via nodriver
-idna==3.15
+idna==3.16
     # via requests
 loguru==0.7.3
     # via weban
@@ -21,8 +21,6 @@ numpy==2.4.6
     #   opencv-python-headless
     #   weban
 opencv-python-headless==4.13.0.92
-    # via weban
-pillow==12.2.0
     # via weban
 pyaes==1.6.1
     # via weban

--- a/uv.lock
+++ b/uv.lock
@@ -68,11 +68,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -179,25 +179,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pillow"
-version = "12.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
-    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
-    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
-    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
-]
-
-[[package]]
 name = "pyaes"
 version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -295,7 +276,6 @@ dependencies = [
     { name = "nodriver" },
     { name = "numpy" },
     { name = "opencv-python-headless" },
-    { name = "pillow" },
     { name = "pyaes" },
     { name = "requests" },
 ]
@@ -311,7 +291,6 @@ requires-dist = [
     { name = "nodriver", specifier = ">=0.50" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "opencv-python-headless", specifier = ">=4.8.0" },
-    { name = "pillow", specifier = ">=12.2.0" },
     { name = "pyaes", specifier = ">=1.6.1" },
     { name = "requests", specifier = ">=2.34.2" },
 ]


### PR DESCRIPTION
## Summary
- Remove `pillow` dependency, replace 2 PIL usages in `captcha.py` with equivalent `cv2` calls
- Remove `PIL` from hiddenimports in Dockerfile and CI build config
- Regenerate `uv.lock` and `requirements.txt` with official PyPI index

## Changes
- `captcha.py`: `Image.open(BytesIO(...)).convert("L")` → `cv2.imdecode(...)` + `Image.fromarray(...).resize(...)` → `cv2.resize(...)`
- `pyproject.toml`: remove `pillow>=12.2.0`
- `Dockerfile` / `.github/workflows/build.yml`: remove `--hidden-import PIL`

## Test plan
- [x] PyInstaller 本地打包通过 (60 MB, -3 MB)
- [x] Docker 镜像构建通过
- [x] 镜像内运行正常