### PR TITLE
feat: add slim Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,24 @@ jobs:
           if-no-files-found: error
 
   docker:
-    name: Docker multi-arch
+    name: Docker ${{ matrix.variant }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: full
+            file: Dockerfile
+            tags: |
+              type=semver,pattern={{version}}
+              type=semver,pattern={{major}}.{{minor}}
+              type=raw,value=latest
+          - variant: slim
+            file: Dockerfile.slim
+            tags: |
+              type=semver,pattern={{version}}-slim
+              type=semver,pattern={{major}}.{{minor}}-slim
+              type=raw,value=slim
     steps:
       - uses: actions/checkout@v6
 
@@ -80,14 +96,12 @@ jobs:
         id: meta
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/weban
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+          tags: ${{ matrix.tags }}
 
       - uses: docker/build-push-action@v7
         with:
           context: .
+          file: ${{ matrix.file }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,0 +1,45 @@
+# ── Builder: PyInstaller 打包 ──────────────────────────────
+FROM python:3.12-slim-bookworm AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends binutils \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir uv
+
+WORKDIR /build
+
+COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project
+
+COPY *.py captcha_model.onnx config.example.toml ./
+COPY answer/ answer/
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv run pyinstaller --noconfirm --onefile \
+    --name WeBan \
+    --add-data "captcha_model.onnx:." \
+    --add-data "answer/answer.json:answer" \
+    --add-data "config.example.toml:." \
+    --hidden-import nodriver \
+    --hidden-import loguru \
+    --hidden-import numpy \
+    --hidden-import cv2 \
+    --collect-submodules nodriver \
+    main.py
+
+# ── Runtime (无内置浏览器) ─────────────────────────────────
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends --no-install-suggests \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /tmp/* \
+    && useradd -m -s /bin/bash appuser \
+    && mkdir -p /app/logs \
+    && chown -R appuser:appuser /app
+
+COPY --from=builder --chown=appuser:appuser /build/dist/WeBan /app/WeBan
+
+USER appuser
+WORKDIR /app
+
+ENTRYPOINT ["/app/WeBan"]

--- a/README.md
+++ b/README.md
@@ -57,20 +57,39 @@ docker run -it --rm \
   hangyi/weban
 ```
 
-**精简镜像**（无内置浏览器，体积更小，需挂载宿主机浏览器）：
+**精简镜像**（无内置浏览器，需通过 CDP 连接宿主机浏览器）：
 
-```bash
-docker run -it --rm \
-  -v "$PWD/config.toml":/app/config.toml:ro \
-  -v "$PWD/logs":/app/logs \
-  -v "/usr/bin/google-chrome:/usr/bin/chromium:ro" \
-  -e CHROMIUM_BINARY=/usr/bin/chromium \
-  --cap-add=SYS_ADMIN \
-  hangyi/weban:slim
-```
+1. 在宿主机启动 Chrome/Edge 并开启远程调试：
 
-> 将 `/usr/bin/google-chrome` 替换为你系统中 Chrome/Chromium 的实际路径。macOS 示例：
-> `-v "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome:/usr/bin/chromium:ro"`
+   ```bash
+   # Linux
+   google-chrome --remote-debugging-port=9222 --user-data-dir=/tmp/chrome-debug
+
+   # macOS
+   "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222 --user-data-dir=/tmp/chrome-debug
+
+   # Windows (PowerShell)
+   & "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222 --user-data-dir=$env:TEMP\chrome-debug
+   ```
+
+2. 在 `config.toml` 中配置 CDP：
+
+   ```toml
+   cdp_host = "host.docker.internal"
+   cdp_port = 9222
+   ```
+
+3. 启动容器：
+
+   ```bash
+   docker run -it --rm \
+     -v "$PWD/config.toml":/app/config.toml:ro \
+     -v "$PWD/logs":/app/logs \
+     --add-host=host.docker.internal:host-gateway \
+     hangyi/weban:slim
+   ```
+
+> Windows 用户推荐使用精简镜像 + CDP 方式，无需挂载浏览器二进制文件。
 
 首次使用先从 [config.example.toml](config.example.toml) 复制一份 `config.toml` 并填写账号信息。
 
@@ -117,6 +136,12 @@ max_workers = 5
 # 浏览器可执行文件路径
 # 留空则自动检测系统中已安装的 Chrome
 browser_path = ""
+
+# CDP 远程调试（连接已有浏览器实例，适用于 Docker 等场景）
+# 在宿主机启动 Chrome: chrome --remote-debugging-port=9222
+# 填写后通过 CDP 连接，不启动本地浏览器；两项需同时设置
+cdp_host = ""
+cdp_port = 0
 
 # 是否启用调试日志
 # 开启后会输出请求体、响应体等详细信息

--- a/README.md
+++ b/README.md
@@ -48,12 +48,29 @@ python main.py # 或 uv run main.py
 
 ### Docker
 
+**完整镜像**（内置 Chromium，开箱即用）：
+
 ```bash
 docker run -it --rm \
   -v "$PWD/config.toml":/app/config.toml:ro \
   -v "$PWD/logs":/app/logs \
   hangyi/weban
 ```
+
+**精简镜像**（无内置浏览器，体积更小，需挂载宿主机浏览器）：
+
+```bash
+docker run -it --rm \
+  -v "$PWD/config.toml":/app/config.toml:ro \
+  -v "$PWD/logs":/app/logs \
+  -v "/usr/bin/google-chrome:/usr/bin/chromium:ro" \
+  -e CHROMIUM_BINARY=/usr/bin/chromium \
+  --cap-add=SYS_ADMIN \
+  hangyi/weban:slim
+```
+
+> 将 `/usr/bin/google-chrome` 替换为你系统中 Chrome/Chromium 的实际路径。macOS 示例：
+> `-v "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome:/usr/bin/chromium:ro"`
 
 首次使用先从 [config.example.toml](config.example.toml) 复制一份 `config.toml` 并填写账号信息。
 

--- a/captcha.py
+++ b/captcha.py
@@ -610,6 +610,8 @@ class CaptchaHandler:
 
     def __init__(self, tenant_code: str, user_id: str, token: str, log,
                  browser_path: Optional[str] = None,
+                 cdp_host: Optional[str] = None,
+                 cdp_port: Optional[int] = None,
                  debug_dir: Optional[Path] = None) -> None:
         """初始化验证码处理器。
 
@@ -618,6 +620,8 @@ class CaptchaHandler:
         :param token: 认证令牌
         :param log: 日志记录器（需支持 info/warning/success 方法）
         :param browser_path: 浏览器可执行文件路径，留空则自动查找
+        :param cdp_host: CDP 远程调试地址，配合 cdp_port 使用时不启动本地浏览器
+        :param cdp_port: CDP 远程调试端口，配合 cdp_host 使用时不启动本地浏览器
         :param debug_dir: 调试图片保存目录，留空则默认 logs/<user_id>/captcha
         """
         self._auth = {
@@ -627,6 +631,8 @@ class CaptchaHandler:
         }
         self.log = log
         self.browser_path = browser_path
+        self.cdp_host = cdp_host
+        self.cdp_port = cdp_port
         self._debug_dir = debug_dir or Path("logs") / user_id / "captcha"
 
     # ── 浏览器 / 页面构建 ──────────────────────────────
@@ -643,11 +649,16 @@ class CaptchaHandler:
         # 仅在显式设置 WEBAN_NO_SANDBOX 或以 root 运行时禁用沙盒
         no_sandbox = os.environ.get("WEBAN_NO_SANDBOX", "").lower() in ("1", "true", "yes")
         browser_args = ["--window-size=428,818", "--mute-audio"]
+        # CDP 模式下传占位路径，避免 nodriver 查找本地浏览器
+        if self.cdp_host and self.cdp_port:
+            browser_path = browser_path or "cdp"
         return await nodriver.start(
             headless=headless,
             browser_executable_path=browser_path or None,
             browser_args=browser_args,
             sandbox=not no_sandbox,
+            host=self.cdp_host,
+            port=self.cdp_port,
         )
 
     async def _inject_auth(self, tab) -> None:

--- a/client.py
+++ b/client.py
@@ -164,6 +164,8 @@ class WeBanClient:
         user: Dict[str, str] | None = None,
         log=logger,
         browser_path: str | None = None,
+        cdp_host: str | None = None,
+        cdp_port: int | None = None,
         debug: bool = False,
         ai_config: Dict[str, Any] | None = None,
     ) -> None:
@@ -174,6 +176,8 @@ class WeBanClient:
         :param user: 已有用户凭据 {"userId": ..., "token": ...}，提供则跳过登录
         :param log: logger 实例
         :param browser_path: 浏览器可执行文件路径，用于验证码处理
+        :param cdp_host: CDP 远程调试地址
+        :param cdp_port: CDP 远程调试端口
         :param debug: 是否启用调试日志
         :param ai_config: AI 搜题配置
         """
@@ -181,6 +185,8 @@ class WeBanClient:
         self.tenant_name = tenant_name.strip()
         self.study_time = 30
         self.browser_path = browser_path
+        self.cdp_host = cdp_host
+        self.cdp_port = cdp_port
         self.ai_config = ai_config
         if user and all([user.get("userId"), user.get("token")]):
             self.api = WeBanAPI(user=user, debug=debug, log=log)
@@ -209,6 +215,8 @@ class WeBanClient:
                 token=self.api.user["token"],
                 log=self.log,
                 browser_path=self.browser_path,
+                cdp_host=self.cdp_host,
+                cdp_port=self.cdp_port,
             )
         return self._captcha_handler
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -41,6 +41,13 @@ max_workers = 5
 # Windows 示例: "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
 browser_path = ""
 
+# CDP 远程调试（连接已有浏览器实例，适用于 Docker 等无法直接启动浏览器的场景）
+# 在宿主机启动 Chrome 时加上: chrome --remote-debugging-port=9222
+# 然后填写以下两项，nodriver 将通过 CDP 连接该浏览器，不再启动本地浏览器
+# 注意: cdp_host 和 cdp_port 需同时设置才生效
+cdp_host = ""
+cdp_port = 0
+
 # 是否启用调试日志
 # 开启后会输出更多日志，比如请求体和响应体，验证码图片等
 debug = false

--- a/main.py
+++ b/main.py
@@ -164,6 +164,8 @@ def run_account(account_config: dict, global_settings: dict, ai_config: dict, ac
     exam_question_time = get_setting("exam_question_time", "3,3")
     exam_submit_match_rate = int(get_setting("exam_submit_match_rate", 90))
     browser_path = get_setting("browser_path", "") or None
+    cdp_host = get_setting("cdp_host", "") or None
+    cdp_port = int(get_setting("cdp_port", 0)) or None
     debug = get_setting("debug", False)
 
     # 为该账号创建专属日志文件夹
@@ -187,14 +189,16 @@ def run_account(account_config: dict, global_settings: dict, ai_config: dict, ac
             user = {"userId": user_id, "token": token_val}
             log.info("使用 Token 登录")
             client = WeBanClient(
-                tenant_name, user=user, log=log, browser_path=browser_path, debug=debug,
+                tenant_name, user=user, log=log, browser_path=browser_path,
+                cdp_host=cdp_host, cdp_port=cdp_port, debug=debug,
                 ai_config=ai_config,
             )
         elif tenant_name and username:
             # 密码登录 — password 默认为 username
             log.info("使用密码登录")
             client = WeBanClient(
-                tenant_name, username, password, log=log, browser_path=browser_path, debug=debug,
+                tenant_name, username, password, log=log, browser_path=browser_path,
+                cdp_host=cdp_host, cdp_port=cdp_port, debug=debug,
                 ai_config=ai_config,
             )
         else:


### PR DESCRIPTION
## Summary
- Add `Dockerfile.slim` — 精简镜像，不内置 Chromium，用户挂载宿主机浏览器
- Update CI to build both `latest` (full) and `slim` variants
- Update README with Docker deployment instructions for both variants

## Size comparison
| Variant | Size |
|---------|------|
| `hangyi/weban:latest` (full) | ~826 MB |
| `hangyi/weban:slim` | ~168 MB |

## Usage
```bash
# 精简镜像 — 挂载宿主机 Chrome
docker run -it --rm \
  -v "$PWD/config.toml":/app/config.toml:ro \
  -v "$PWD/logs":/app/logs \
  -v "/usr/bin/google-chrome:/usr/bin/chromium:ro" \
  -e CHROMIUM_BINARY=/usr/bin/chromium \
  --cap-add=SYS_ADMIN \
  hangyi/weban:slim
```

## Test plan
- [x] `Dockerfile.slim` 本地构建通过
- [x] 精简镜像可正常启动
- [x] CI build.yml matrix 配置正确