### PR TITLE
fix: Docker 环境禁用 Chromium sandbox 及优化题库加载优先级

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,5 +43,6 @@ USER appuser
 WORKDIR /app
 
 ENV CHROMIUM_BINARY=/usr/bin/chromium
+ENV WEBAN_NO_SANDBOX=1
 
 ENTRYPOINT ["/app/WeBan"]

--- a/captcha.py
+++ b/captcha.py
@@ -681,9 +681,12 @@ def check_browser_health(
             "未找到浏览器，请安装 Chrome 或设置 browser_path / CHROMIUM_BINARY 环境变量"
         )
     try:
+        args = [resolved, "--headless=new", "--no-first-run", "--disable-gpu",
+                "--dump-dom", "data:text/html,<h1>ok</h1>"]
+        if os.environ.get("WEBAN_NO_SANDBOX", "").lower() in ("1", "true", "yes"):
+            args.append("--no-sandbox")
         proc = subprocess.run(
-            [resolved, "--headless=new", "--no-first-run", "--disable-gpu",
-             "--dump-dom", "data:text/html,<h1>ok</h1>"],
+            args,
             capture_output=True, timeout=10,
         )
         if proc.returncode != 0 or b"ok" not in proc.stdout:

--- a/client.py
+++ b/client.py
@@ -23,6 +23,7 @@ else:
     bundle_path = base_path
 answer_dir = os.path.join(base_path, "answer")
 answer_path = os.path.join(answer_dir, "answer.json")
+root_answer_path = os.path.join(base_path, "answer.json")
 bundle_answer_path = os.path.join(bundle_path, "answer", "answer.json")
 
 
@@ -249,7 +250,13 @@ class WeBanClient:
         :return: 清洗后的题目标题 → 正确答案内容列表的映射
         """
         answers: dict = {}
-        load_path = answer_path if os.path.exists(answer_path) else bundle_answer_path
+        # 优先级: 根目录 answer.json > answer/answer.json > 打包内置
+        if os.path.exists(root_answer_path):
+            load_path = root_answer_path
+        elif os.path.exists(answer_path):
+            load_path = answer_path
+        else:
+            load_path = bundle_answer_path
         try:
             with open(load_path, encoding="utf-8") as f:
                 for title, options in json.load(f).items():


### PR DESCRIPTION
## 修改内容

### 1. Docker 环境禁用 Chromium sandbox
- Dockerfile 添加  环境变量
- Docker 容器默认没有 Linux 内核沙盒权限，Chromium 需要  才能启动

### 2. 修复浏览器健康检查
-  的  函数之前没有读取  环境变量
- 导致 Docker 环境下浏览器检测失败，程序无法启动

### 3. 优化题库加载优先级
- 新增根目录  作为最高优先级
- 加载顺序：根目录 answer.json > answer/answer.json > 打包内置
- 方便用户直接挂载单个文件而不必挂载整个 answer 文件夹

## 测试
Docker 运行命令：
```bash
docker run -it -v $(pwd)/config.toml:/app/config.toml -v $(pwd)/answer:/app/answer hangyi/weban
```