### PR TITLE
fix: 对齐完课请求，避免 10018 误判

### DIFF
--- a/api.py
+++ b/api.py
@@ -754,11 +754,12 @@ class WeBanAPI:
         :param user_course_id: 用户课程 ID
         :param token: 验证码获取的 token，weiban 模式会替代 URL 中的 id
         :param course_type: 决定接口——"weiban"（JSONP GET，需绕过跨域）、"open"（POST）、"moon"（POST）
-        :param unique_no: 微课专用唯一标识
-        :param referer: 课程来源
+        :param unique_no: 仅 apicenext 课程传入；与翻页共用同一 uuid。普通课不传
+          （sdk.js: `if (typeof uuid !== 'undefined') opts.uniqueNo = uuid`）
+        :param referer: JSONP 完课 Referer，默认 mcwk 根路径（与浏览器 script 请求一致）
         :return: 完成结果 dict
         JSONP 模式是因为 weiban 服务端返回 callback 包裹而非 JSON，前端通过 <script> 标签跨域拉取。
-        detailCode=10018 表示服务端进度尚未落库，采用指数退避重试（3/6/10/15/20 秒，最多 6 次）。
+        detailCode=10018 表示「系统检测到您的行为存在异常」，不是进度未落库，禁止重试。
         """
         data = {"userCourseId": user_course_id, "tenantCode": self.tenant_code}
         if unique_no:
@@ -772,33 +773,43 @@ class WeBanAPI:
             url = f"{self.baseurl}/pharos/usercourse/v2/{token or user_course_id}.do"
 
         is_jsonp = course_type not in ("open", "moon")
-        for attempt in range(6):
-            if is_jsonp:
-                ts = int(self.get_timestamp(13, 0))
-                cb = f"jQuery3410{randint(10**15, 10**16 - 1)}_{ts}"
-                response = self.session.get(
-                    url,
-                    params={**data, "callback": cb, "_": ts + 1},
-                    timeout=self.timeout,
-                )
-            else:
-                response = self.session.post(url, data=data, timeout=self.timeout)
+        if is_jsonp:
+            ts = int(self.get_timestamp(13, 0))
+            cb = f"jQuery3410{randint(10**15, 10**16 - 1)}_{ts}"
+            headers = {
+                "Accept": "*/*",
+                "Referer": referer or "https://mcwk.mycourse.cn/",
+                "X-Token": None,
+            }
+            response = self.session.get(
+                url,
+                params={**data, "callback": cb, "_": ts + 1},
+                headers=headers,
+                timeout=self.timeout,
+            )
+        else:
+            response = self.session.post(url, data=data, timeout=self.timeout)
+
+        if response.status_code == 701 or "Account locked" in response.text:
+            return {
+                "code": "-1",
+                "detailCode": "701",
+                "msg": "Account locked",
+                "raw": response.text,
+            }
+
+        try:
+            result = response.json()
+        except json.JSONDecodeError:
+            text = response.text
+            s, e = text.find("("), text.rfind(")")
+            if s != -1 and e != -1:
+                text = text[s + 1 : e]
             try:
-                result = response.json()
+                result = json.loads(text)
             except json.JSONDecodeError:
-                text = response.text
-                s, e = text.find("("), text.rfind(")")
-                if s != -1 and e != -1:
-                    text = text[s + 1 : e]
-                try:
-                    result = json.loads(text)
-                except json.JSONDecodeError:
-                    return {"raw": response.text}
-            if result.get("detailCode") == "10018" and attempt < 5:
-                time.sleep((3, 6, 10, 15, 20)[attempt])
-                continue
-            return result
-        return {}  # unreachable, satisfies type checker
+                return {"raw": response.text}
+        return result
 
     def finish_lyra(self, user_activity_id: str) -> Dict[str, Any]:
         """完成安全实训（Lyra 独立微服务，不走 _post 统一入口）
@@ -911,6 +922,9 @@ class WeBanAPI:
         ticket: str,
     ) -> Dict[str, Any]:
         """验证码校验（课程完成时），appId: 195119536
+
+        浏览器从 mcwk 页面 jQuery.post 发出：无 timestamp query、无 X-Token，
+        Origin/Referer 为 mcwk。不走 _post，避免多带 timestamp 和默认头。
         :param user_course_id: 用户课程 ID
         :param user_project_id: 用户项目 ID
         :param course_id: 课程 ID
@@ -918,18 +932,28 @@ class WeBanAPI:
         :param ticket: 验证码票据
         :return: 校验结果 dict
         {"code":"0","data":"${token}","detailCode":"0"}
-
         """
-        return self._post(
-            "/pharos/usercourse/check.do",
-            {
-                "userCourseId": user_course_id,
-                "userProjectId": user_project_id,
-                "courseId": course_id,
-                "randstr": randstr,
-                "ticket": ticket,
-            },
+        url = f"{self.baseurl}/pharos/usercourse/check.do"
+        data = {
+            "userId": self.user["userId"],
+            "userCourseId": user_course_id,
+            "userProjectId": user_project_id,
+            "courseId": course_id,
+            "tenantCode": self.tenant_code,
+            "randstr": randstr,
+            "ticket": ticket,
+        }
+        headers = {
+            "Accept": "*/*",
+            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "Origin": "https://mcwk.mycourse.cn",
+            "Referer": "https://mcwk.mycourse.cn/",
+            "X-Token": None,
+        }
+        response = self.session.post(
+            url, data=data, headers=headers, timeout=self.timeout
         )
+        return handle_response(response)
 
     def exam_check_verify_code(
         self, user_exam_plan_id: str, verfy_code: str, verify_time: int | None

--- a/client.py
+++ b/client.py
@@ -521,7 +521,7 @@ class WeBanClient:
                                 + d["pushFinishedNum"]
                                 + d["optionalFinishedNum"]
                             )
-                        self._study_one_course(
+                        ok = self._study_one_course(
                             course,
                             task,
                             category_prefix,
@@ -529,6 +529,11 @@ class WeBanClient:
                             answers_json,
                             force_restudy,
                         )
+                        if not ok:
+                            self.log.error(
+                                "检测到行为异常或账号锁定，已停止本账号后续学习"
+                            )
+                            return
                         progress_after = self.get_progress(
                             task["userProjectId"], project_prefix
                         )
@@ -546,6 +551,20 @@ class WeBanClient:
 
             self.log.success(f"{project_prefix} 课程学习完成")
 
+    @staticmethod
+    def _is_account_blocked(res: dict) -> bool:
+        """完课/接口返回是否表示行为异常或账号锁定，应立即停跑。"""
+        if not res:
+            return False
+        detail = str(res.get("detailCode", ""))
+        msg = str(res.get("msg", ""))
+        raw = str(res.get("raw", ""))
+        if detail in {"10018", "701"}:
+            return True
+        if "行为存在异常" in msg or "Account locked" in raw or "Account locked" in msg:
+            return True
+        return False
+
     def _study_one_course(
         self,
         course: dict,
@@ -554,12 +573,15 @@ class WeBanClient:
         project_prefix: str,
         answers_json: dict,
         force_restudy: bool,
-    ) -> None:
-        """处理单门课程：有 apinext 的走翻页流程，没 apinext 的直接答题+完课"""
+    ) -> bool:
+        """处理单门课程：有 apinext 的走翻页流程，没 apinext 的直接答题+完课。
+
+        :return: True 可继续下一门；False 表示账号异常/锁定，应停止本账号
+        """
         course_prefix = f"{category_prefix}/{course['resourceName']}"
 
         if not force_restudy and int(course.get("finished", 0)) == 1:
-            return
+            return True
 
         self.log.info(f"学习： {course_prefix}")
         self.api.study(course["resourceId"], task["userProjectId"])
@@ -567,7 +589,7 @@ class WeBanClient:
 
         if "userCourseId" not in course:
             self.log.success(f"{course_prefix} 完成")
-            return
+            return True
 
         course_url = self._build_course_url(course, task)
         self.log.info(f"{course_prefix}：{course_url.split('?')[0]}")
@@ -582,13 +604,20 @@ class WeBanClient:
         item_info = (
             self.parse_item_js(course_code, course_url=course_url)
             if course_code
-            else {"nonstr_map": {}, "has_exam": False, "total_step": 0}
+            else {
+                "uses_apinext": False,
+                "nonstr_map": {},
+                "has_exam": False,
+                "total_step": 0,
+            }
         )
 
-        unique_no = str(uuid4())
         nonstr_map = item_info.get("nonstr_map", {})
         total_step = item_info.get("total_step", 0)
         uses_apinext = item_info.get("uses_apinext", False)
+        # sdk.js 仅在 apicenext.js 定义了全局 uuid 时才带 uniqueNo；
+        # 无 apinext 的课传 uniqueNo 会被判行为异常 (10018)
+        unique_no = str(uuid4()) if uses_apinext else None
 
         if uses_apinext:
             self.api.init_index(task["userProjectId"])
@@ -604,7 +633,7 @@ class WeBanClient:
                 task["userProjectId"],
                 nonstr_map,
                 total_step,
-                unique_no=unique_no,
+                unique_no=unique_no or "",
                 finish=2,
             )
 
@@ -663,7 +692,7 @@ class WeBanClient:
                 task["userProjectId"],
                 nonstr_map,
                 total_step,
-                unique_no=unique_no,
+                unique_no=unique_no or "",
                 finish=1,
             )
             time.sleep(2)
@@ -672,9 +701,12 @@ class WeBanClient:
         res = self._finish_course(course, task, query, course_url, unique_no)
         if res.get("code", "-1") != "0":
             self.log.error(f"{course_prefix} 完成失败：{res}")
-            return
+            if self._is_account_blocked(res):
+                return False
+            return True
 
         self.log.success(f"{course_prefix} 完成")
+        return True
 
     def _finish_course(
         self,
@@ -682,7 +714,7 @@ class WeBanClient:
         task: dict,
         query: dict,
         course_url: str,
-        unique_no: str,
+        unique_no: str | None,
     ) -> dict:
         """调用正确的完课接口并返回响应
 
@@ -695,7 +727,7 @@ class WeBanClient:
         :param task: 任务数据
         :param query: URL 查询参数（parse_qs 格式）
         :param course_url: 完整课程 URL（用于 captcha）
-        :param unique_no: apinext 使用的唯一标识
+        :param unique_no: 仅 apinext 课程传入；None 表示不传 uniqueNo
         :return: 完课 API 响应
         """
         if query.get("lyra", [None])[0] == "lyra":
@@ -705,7 +737,11 @@ class WeBanClient:
         if query.get("source", [None])[0] == "moon":
             return self.api.finish_by_token(course["userCourseId"], course_type="moon")
 
-        finish_kwargs = {"unique_no": unique_no}
+        finish_kwargs: dict = {
+            "referer": "https://mcwk.mycourse.cn/",
+        }
+        if unique_no:
+            finish_kwargs["unique_no"] = unique_no
         if query.get("csCapt", [None])[0] == "true":
             try:
                 captcha_result = self.captcha_handler.handle_course_captcha(


### PR DESCRIPTION
## Summary
- 无 apinext 课程完课不再传 `uniqueNo`（对齐 sdk.js）
- 完课 JSONP / `check.do` 对齐 mcwk 请求头，去掉多余 `X-Token`/`timestamp`
- `10018` / 账号锁定立即停跑，不再重试

## Test plan
- [ ] 无 apinext + `csCapt` 课程完课成功
- [ ] 有 apinext 课程仍带同一 `uniqueNo` 完课
- [ ] 收到 10018/701 后该账号停止后续学习