### PR TITLE
ci: 版本号单一来源，tag 注入，不再硬编码

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,42 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  version:
+    name: Resolve version
+    runs-on: ubuntu-latest
+    outputs:
+      app_version: ${{ steps.resolve.outputs.app_version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version
+        id: resolve
+        shell: bash
+        run: |
+          py_ver=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            # tag 触发：tag 号必须与 pyproject.toml 的 version 一致
+            tag_ver="${GITHUB_REF#refs/tags/v}"
+            if [[ "$tag_ver" != "$py_ver" ]]; then
+              echo "::error::版本不一致：tag ${tag_ver} 与 pyproject.toml ${py_ver} 不符，请对齐后再打 tag" >&2
+              exit 1
+            fi
+            # tag 命中 HEAD 为 3.8.6，tag 后又有提交为 3.8.6-gabcdef
+            app_version=$(git describe --tags --always | sed 's/^v//' | sed 's/-[0-9]*-g/-/')
+          else
+            # 非 tag 触发：用 pyproject.toml 里的静态版本
+            app_version="$py_ver"
+          fi
+
+          echo "app_version=${app_version}" >> "$GITHUB_OUTPUT"
+          echo "产物版本：${app_version}"
+
   build:
     name: Build ${{ matrix.os }}
+    needs: version
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -25,12 +59,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Inject version from tag
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Inject version
         shell: bash
+        env:
+          APP_VERSION: ${{ needs.version.outputs.app_version }}
         run: |
-          ver="${GITHUB_REF#refs/tags/v}"
-          python - "$ver" <<'PY'
+          python3 - "$APP_VERSION" <<'PY'
           import re, sys
           ver = sys.argv[1]
           p = "pyproject.toml"
@@ -85,6 +119,7 @@ jobs:
 
   docker:
     name: Docker ${{ matrix.variant }} ${{ matrix.platform }}
+    needs: version
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -101,16 +136,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Resolve app version
-        id: ver
-        shell: bash
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
-          else
-            echo "version=" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: docker/setup-buildx-action@v4
 
       - uses: docker/login-action@v4
@@ -126,7 +151,7 @@ jobs:
           target: ${{ matrix.variant }}
           platforms: ${{ matrix.platform }}
           build-args: |
-            APP_VERSION=${{ steps.ver.outputs.version }}
+            APP_VERSION=${{ needs.version.outputs.app_version }}
           outputs: type=image,name=${{ secrets.DOCKERHUB_USERNAME }}/weban,push-by-digest=true,name-canonical=true,push=true
           provenance: false
           cache-from: type=gha,scope=docker-${{ matrix.variant }}-${{ matrix.arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Inject version from tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          ver="${GITHUB_REF#refs/tags/v}"
+          python - "$ver" <<'PY'
+          import re, sys
+          ver = sys.argv[1]
+          p = "pyproject.toml"
+          s = open(p, encoding="utf-8").read()
+          s2, n = re.subn(r'^version = ".*?"', f'version = "{ver}"', s, count=1, flags=re.M)
+          if n != 1:
+              raise SystemExit(f"未在 {p} 中找到 version 字段")
+          open(p, "w", encoding="utf-8").write(s2)
+          print(f"已注入版本 {ver}")
+          PY
+
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           python-version: "3.12"
@@ -50,6 +67,7 @@ jobs:
             --add-data "captcha_model.onnx${sep}." \
             --add-data "answer/answer.json${sep}answer/answer.json" \
             --add-data "config.example.toml${sep}." \
+            --add-data "pyproject.toml${sep}." \
             --hidden-import nodriver \
             --hidden-import loguru \
             --hidden-import numpy \
@@ -83,6 +101,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Resolve app version
+        id: ver
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: docker/setup-buildx-action@v4
 
       - uses: docker/login-action@v4
@@ -97,6 +125,8 @@ jobs:
           file: Dockerfile
           target: ${{ matrix.variant }}
           platforms: ${{ matrix.platform }}
+          build-args: |
+            APP_VERSION=${{ steps.ver.outputs.version }}
           outputs: type=image,name=${{ secrets.DOCKERHUB_USERNAME }}/weban,push-by-digest=true,name-canonical=true,push=true
           provenance: false
           cache-from: type=gha,scope=docker-${{ matrix.variant }}-${{ matrix.arch }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends binutils \
 
 WORKDIR /build
 
+ARG APP_VERSION
 COPY pyproject.toml uv.lock ./
+RUN if [ -n "$APP_VERSION" ]; then \
+      python -c "import re,sys; \
+p='pyproject.toml'; s=open(p,encoding='utf-8').read(); \
+s2,n=re.subn(r'^version = \".*?\"', f'version = \"{sys.argv[1]}\"', s, count=1, flags=re.M); \
+assert n==1, 'version field not found'; open(p,'w',encoding='utf-8').write(s2)" "$APP_VERSION"; \
+    fi
+
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-install-project
 
@@ -25,6 +33,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --add-data "captcha_model.onnx:." \
     --add-data "answer/answer.json:answer/answer.json" \
     --add-data "config.example.toml:." \
+    --add-data "pyproject.toml:." \
     --hidden-import nodriver \
     --hidden-import loguru \
     --hidden-import numpy \

--- a/main.py
+++ b/main.py
@@ -12,7 +12,34 @@ from loguru import logger
 from client import WeBanClient
 from captcha import check_browser_health
 
-VERSION = "v3.8.3"
+
+def _resolve_version() -> str:
+    """版本号单一来源：pyproject.toml（打包后从冻结资源读取），importlib.metadata 作回退"""
+    candidates = []
+    if getattr(sys, "frozen", False):
+        bundle = getattr(sys, "_MEIPASS", None)
+        if bundle:
+            candidates.append(os.path.join(bundle, "pyproject.toml"))
+    candidates.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "pyproject.toml"))
+
+    for path in candidates:
+        try:
+            with open(path, "rb") as f:
+                version = tomllib.load(f).get("project", {}).get("version")
+            if version:
+                return version
+        except (OSError, tomllib.TOMLDecodeError):
+            continue
+
+    try:
+        from importlib.metadata import version as _dist_version
+
+        return _dist_version("weban")
+    except Exception:
+        return "unknown"
+
+
+VERSION = f"v{_resolve_version()}"
 
 if getattr(sys, "frozen", False):
     base_path = os.path.dirname(os.path.abspath(sys.executable))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "weban"
-version = "3.8.3"
+version = "3.8.6"
 description = "auto finish weiban"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"


### PR DESCRIPTION
Closes #129

- 版本号只留在 `pyproject.toml`，`main.py` 读取它动态获取，删除硬编码
- PyInstaller 与 Dockerfile 均把 `pyproject.toml` 打进冻结产物
- Release 构建从 tag（`v3.8.5`）注入版本到 `pyproject.toml` 再打包；非 tag 触发不注入