### PR TITLE
feat: 优化时间预估并修复 ruff/pyright 错误

### DIFF
--- a/api.py
+++ b/api.py
@@ -3,11 +3,11 @@ import json
 import time
 from base64 import b64encode, urlsafe_b64decode, urlsafe_b64encode
 from random import randint
-from typing import Any, Dict
+from typing import Any, ClassVar
 from uuid import uuid4
 
-import requests
 import pyaes
+import requests
 from loguru import logger
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -18,7 +18,7 @@ def pkcs7_pad(data: bytes, block_size: int = 16) -> bytes:
     return data + bytes([pad_len] * pad_len)
 
 
-def handle_response(response: requests.Response) -> Dict[str, Any]:
+def handle_response(response: requests.Response) -> dict[str, Any]:
     """处理接口响应"""
     if response.status_code != 200:
         if response.status_code == 403:
@@ -41,7 +41,7 @@ class LoggingSession:
     backoff_factor=1），外层捕获 RequestException 记日志后抛回。
     """
 
-    DEFAULT_HEADERS = {
+    DEFAULT_HEADERS: ClassVar[dict[str, str]] = {
         "User-Agent": (
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
             "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
@@ -104,7 +104,7 @@ class WeBanAPI:
         tenant_code: str | None = None,
         account: str | None = None,
         password: str | None = None,
-        user: Dict[str, str] | None = None,
+        user: dict[str, str] | None = None,
         timeout: int | tuple = (9.05, 15),
         debug: bool = False,
         log=logger,
@@ -159,7 +159,7 @@ class WeBanAPI:
         endpoint: str,
         data: dict | None = None,
         timestamp_args: tuple | None = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         通用 POST 请求，封装所有端点共用的模板代码。
         自动拼接 baseurl、timestamp 置入 query、注入 tenantCode 到 body。
@@ -185,7 +185,7 @@ class WeBanAPI:
         )
         return handle_response(response)
 
-    def _mercury_request(self, params: dict) -> Dict[str, Any]:
+    def _mercury_request(self, params: dict) -> dict[str, Any]:
         """
         mercuryprovider 通用请求。会将 appKey/format/v/timestamp/clientId 标准参数与传入 params 合并，
         按 key 字母序拼接成 sign_str，用固定密钥 75uet0kwvnc90xo 做包装式 SHA1 签名。
@@ -225,7 +225,7 @@ class WeBanAPI:
         """
         self.tenant_code = tenant_code
 
-    def get_tenant_list_with_letter(self) -> Dict[str, Any]:
+    def get_tenant_list_with_letter(self) -> dict[str, Any]:
         """
         获取学校代码和名称列表
 
@@ -249,7 +249,7 @@ class WeBanAPI:
         )
         return handle_response(response)
 
-    def get_tenant_config(self, tenant_code: str | None = None) -> Dict[str, Any]:
+    def get_tenant_config(self, tenant_code: str | None = None) -> dict[str, Any]:
         """
         获取学校配置
 
@@ -280,7 +280,7 @@ class WeBanAPI:
         )
         return handle_response(response)
 
-    def get_simple_config(self, tenant_code: str | None = None) -> Dict[str, Any]:
+    def get_simple_config(self, tenant_code: str | None = None) -> dict[str, Any]:
         """
         获取简单配置
         :param tenant_code: 学校代码
@@ -291,7 +291,7 @@ class WeBanAPI:
             {"tenantCode": tenant_code or self.tenant_code},
         )
 
-    def get_help(self, tenant_code: str | None = None) -> Dict[str, Any]:
+    def get_help(self, tenant_code: str | None = None) -> dict[str, Any]:
         """
         获取帮助文件
         :return:
@@ -317,7 +317,7 @@ class WeBanAPI:
         response = self.session.get(url, params=params, timeout=self.timeout)
         return response.content
 
-    def login(self, verify_code: str, verify_time: int | None) -> Dict[str, Any]:
+    def login(self, verify_code: str, verify_time: int | None) -> dict[str, Any]:
         """
         登录，请求体经 AES-ECB 加密后发送。成功后自动将 token、userId 存入 self.user 并更新 X-Token 头。
         :param verify_code: 用户输入的验证码
@@ -386,7 +386,7 @@ class WeBanAPI:
     # 首页 / 项目
     # ========================================================================
 
-    def list_completion(self) -> Dict[str, Any]:
+    def list_completion(self) -> dict[str, Any]:
         """
         获取模块
         :return:
@@ -430,7 +430,7 @@ class WeBanAPI:
         """
         return self._post("/pharos/index/listCompletion.do")
 
-    def lab_index(self) -> Dict[str, Any]:
+    def lab_index(self) -> dict[str, Any]:
         """
         获取实验室模块信息
         :return:
@@ -467,7 +467,7 @@ class WeBanAPI:
         # 该端点要求 timestamp 带 1 位小数（如 1234567890.1）
         return self._post("/pharos/lab/index.do", timestamp_args=(10, 1))
 
-    def list_study_task(self) -> Dict[str, Any]:
+    def list_study_task(self) -> dict[str, Any]:
         """获取学习任务列表
         :return: 学习任务列表 dict
         {
@@ -506,7 +506,7 @@ class WeBanAPI:
         """
         return self._post("/pharos/index/listStudyTask.do")
 
-    def list_my_project(self, ended: int = 2) -> Dict[str, Any]:
+    def list_my_project(self, ended: int = 2) -> dict[str, Any]:
         """
         获取我的项目列表。
         :param ended: 1=已结束, 2=未结束/进行中（默认 2）
@@ -537,7 +537,7 @@ class WeBanAPI:
         """
         return self._post("/pharos/index/listMyProject.do", {"ended": ended})
 
-    def show_progress(self, user_project_id: str) -> Dict[str, Any]:
+    def show_progress(self, user_project_id: str) -> dict[str, Any]:
         """获取学习任务进度
         :param user_project_id: 用户项目 ID
         :return: 进度 dict
@@ -573,13 +573,13 @@ class WeBanAPI:
             "/pharos/project/showProgress.do", {"userProjectId": user_project_id}
         )
 
-    def list_valve(self) -> Dict[str, Any]:
+    def list_valve(self) -> dict[str, Any]:
         """获取项目页功能开关
         :return: 功能开关 dict
         """
         return self._post("/pharos/index/listValve.do")
 
-    def get_next_task(self, user_project_id: str) -> Dict[str, Any]:
+    def get_next_task(self, user_project_id: str) -> dict[str, Any]:
         """获取项目下一步状态
         :param user_project_id: 用户项目 ID
         :return: 下一步状态 dict
@@ -588,7 +588,7 @@ class WeBanAPI:
             "/pharos/project/getNextTask.do", {"userProjectId": user_project_id}
         )
 
-    def get_project_simple(self, user_project_id: str) -> Dict[str, Any]:
+    def get_project_simple(self, user_project_id: str) -> dict[str, Any]:
         """获取项目基础模式信息
         :param user_project_id: 用户项目 ID
         :return: 项目基础信息 dict
@@ -603,7 +603,7 @@ class WeBanAPI:
 
     def list_category(
         self, user_project_id: str, choose_type: int = 3
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """获取课程分类列表
         :param user_project_id: 用户项目 ID
         :param choose_type: 课程类型（1=推送课, 2=自选课, 3=必修课）
@@ -629,7 +629,7 @@ class WeBanAPI:
 
     def list_course(
         self, user_project_id: str, category_code: str, choose_type: int = 3
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """获取课程列表
         :param user_project_id: 用户项目 ID
         :param category_code: 分类代码
@@ -664,7 +664,7 @@ class WeBanAPI:
             },
         )
 
-    def init_index(self, user_project_id: str) -> Dict[str, Any]:
+    def init_index(self, user_project_id: str) -> dict[str, Any]:
         """初始化课程索引（开始学习前调用，模拟浏览器行为）
         :param user_project_id: 用户项目 ID
         :return: 初始化结果 dict
@@ -674,7 +674,7 @@ class WeBanAPI:
             "/pharos/usercourse/initIndex.do", {"userProjectId": user_project_id}
         )
 
-    def study(self, course_id: str, user_project_id: str) -> Dict[str, Any]:
+    def study(self, course_id: str, user_project_id: str) -> dict[str, Any]:
         """开始学习课程
         :param course_id: 课程 ID
         :param user_project_id: 用户项目 ID
@@ -689,7 +689,7 @@ class WeBanAPI:
             {"courseId": course_id, "userProjectId": user_project_id},
         )
 
-    def get_course_url(self, course_id: str, user_project_id: str) -> Dict[str, Any]:
+    def get_course_url(self, course_id: str, user_project_id: str) -> dict[str, Any]:
         """获取课程链接
         :param course_id: 课程 ID
         :param user_project_id: 用户项目 ID
@@ -707,7 +707,7 @@ class WeBanAPI:
 
     def invoke_captcha(
         self, user_course_id: str, user_project_id: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         通过验证码获取完成 token。
         不走 OCR —— 验证码是"找出正确汉字"，但后端仅校验坐标，
@@ -748,7 +748,7 @@ class WeBanAPI:
         course_type: str | None = "weiban",
         unique_no: str | None = None,
         referer: str | None = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         通过 userCourseId 或验证码 token 完成课程。
         :param user_course_id: 用户课程 ID
@@ -811,7 +811,7 @@ class WeBanAPI:
                 return {"raw": response.text}
         return result
 
-    def finish_lyra(self, user_activity_id: str) -> Dict[str, Any]:
+    def finish_lyra(self, user_activity_id: str) -> dict[str, Any]:
         """完成安全实训（Lyra 独立微服务，不走 _post 统一入口）
         :param user_activity_id: 用户活动 ID
         :return: 完成结果 dict
@@ -828,7 +828,7 @@ class WeBanAPI:
     # 考试
     # ========================================================================
 
-    def exam_list_plan(self, user_project_id: str) -> Dict[str, Any]:
+    def exam_list_plan(self, user_project_id: str) -> dict[str, Any]:
         """获取考试计划列表
         :param user_project_id: 用户项目 ID
         :return: 考试计划列表 dict
@@ -862,7 +862,7 @@ class WeBanAPI:
             "/pharos/exam/listPlan.do", {"userProjectId": user_project_id}
         )
 
-    def exam_before_paper(self, user_exam_plan_id: str) -> Dict[str, Any]:
+    def exam_before_paper(self, user_exam_plan_id: str) -> dict[str, Any]:
         """获取是否有未提交的答案
         :param user_exam_plan_id: 用户考试计划 ID
         :return: 未提交答案信息 dict
@@ -878,7 +878,7 @@ class WeBanAPI:
             "/pharos/exam/beforePaper.do", {"userExamPlanId": user_exam_plan_id}
         )
 
-    def exam_prepare_paper(self, user_exam_plan_id: str) -> Dict[str, Any]:
+    def exam_prepare_paper(self, user_exam_plan_id: str) -> dict[str, Any]:
         """准备考试
         :param user_exam_plan_id: 用户考试计划 ID
         :return: 考试准备结果 dict
@@ -900,7 +900,7 @@ class WeBanAPI:
 
     def exam_check(
         self, user_exam_plan_id: str, randstr: str, ticket: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """无感验证码校验（考试前），appId: 190330343
         :param user_exam_plan_id: 用户考试计划 ID
         :param randstr: 验证码随机串
@@ -920,7 +920,7 @@ class WeBanAPI:
         course_id: str,
         randstr: str,
         ticket: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """验证码校验（课程完成时），appId: 195119536
 
         浏览器从 mcwk 页面 jQuery.post 发出：无 timestamp query、无 X-Token，
@@ -957,7 +957,7 @@ class WeBanAPI:
 
     def exam_check_verify_code(
         self, user_exam_plan_id: str, verfy_code: str, verify_time: int | None
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """检查考试验证码
         :param user_exam_plan_id: 用户考试计划 ID
         :param verfy_code: 验证码
@@ -977,7 +977,7 @@ class WeBanAPI:
             },
         )
 
-    def exam_start_paper(self, user_exam_plan_id: str) -> Dict[str, Any]:
+    def exam_start_paper(self, user_exam_plan_id: str) -> dict[str, Any]:
         """开始考试，返回试卷题目列表（data 字段含 questionList 数组，每题有 questionId/answerIds 等字段）
         :param user_exam_plan_id: 用户考试计划 ID
         :return: 试卷题目列表 dict
@@ -1046,7 +1046,7 @@ class WeBanAPI:
         use_time: int,
         answer_ids: list | None,
         exam_plan_id: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """记录考试答案
         :param user_exam_plan_id: 用户考试计划 ID
         :param question_id: 题目 ID
@@ -1069,7 +1069,7 @@ class WeBanAPI:
             data["answerIds"] = ",".join(answer_ids)
         return self._post("/pharos/exam/recordQuestion.do", data)
 
-    def exam_submit_paper(self, user_exam_plan_id: str) -> Dict[str, Any]:
+    def exam_submit_paper(self, user_exam_plan_id: str) -> dict[str, Any]:
         """提交考试
         :param user_exam_plan_id: 用户考试计划 ID
         :return: 提交结果 dict
@@ -1092,7 +1092,7 @@ class WeBanAPI:
             "/pharos/exam/submitPaper.do", {"userExamPlanId": user_exam_plan_id}
         )
 
-    def exam_fresh_paper(self, user_exam_plan_id: str) -> Dict[str, Any]:
+    def exam_fresh_paper(self, user_exam_plan_id: str) -> dict[str, Any]:
         """重置考试题目
         :param user_exam_plan_id: 用户考试计划 ID
         :return: 刷新结果 dict
@@ -1140,7 +1140,7 @@ class WeBanAPI:
 
     def exam_review_paper(
         self, user_exam_id: str, is_retake: int = 2
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """查看考试结果
         :param user_exam_id: 用户考试 ID
         :param is_retake: 1=补考, 2=正常考试
@@ -1188,7 +1188,7 @@ class WeBanAPI:
             {"userExamId": user_exam_id, "isRetake": is_retake},
         )
 
-    def exam_list_history(self, exam_plan_id: str, exam_type: int) -> Dict[str, Any]:
+    def exam_list_history(self, exam_plan_id: str, exam_type: int) -> dict[str, Any]:
         """获取考试历史记录
         :param exam_plan_id: 考试计划 ID
         :param exam_type: 考试类型
@@ -1245,7 +1245,7 @@ class WeBanAPI:
         finish: int = 2,
         nonstr: str = "",
         unique_no: str | None = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         学习进度追踪接口，部分课程需要此接口记录翻页和完成状态。
         :param user_course_id: 用户课程 ID
@@ -1293,7 +1293,7 @@ class WeBanAPI:
         )
         return handle_response(response)
 
-    def list_question(self, course_id: str) -> Dict[str, Any]:
+    def list_question(self, course_id: str) -> dict[str, Any]:
         """获取课后习题列表（course_id 为 resourceId UUID）
         :param course_id: 课程 ID（resourceId UUID）
         :return: 习题列表 dict
@@ -1338,7 +1338,7 @@ class WeBanAPI:
 
     def save_question(
         self, course_id: str, question_id: str, answers: str, source: str = "WEIBAN"
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """提交课中观点题答案
         :param course_id: 课程 ID
         :param question_id: 题目 ID
@@ -1365,7 +1365,7 @@ class WeBanAPI:
 
     def save_exam_question(
         self, course_id: str, question_id: str, answers: str, source: str = "WEIBAN"
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """提交课后习题答案
         :param course_id: 课程 ID
         :param question_id: 题目 ID

--- a/captcha.py
+++ b/captcha.py
@@ -16,20 +16,20 @@ import json
 import logging
 import os
 import platform
+import random
 import shutil
 import subprocess
 import sys
-import random
 import threading
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, ClassVar
 
 import cv2
+import nodriver
 import numpy as np
 import requests
-import nodriver
 from nodriver import cdp
 from nodriver.cdp.runtime import DeepSerializedValue
 
@@ -143,7 +143,7 @@ _QUERY_JS = r"""
 
 def normalize_mask(
     binary_mask: np.ndarray, canvas_size: int = 48, symbol_size: int = 34
-) -> Optional[np.ndarray]:
+) -> np.ndarray | None:
     """将二值 mask 缩放到固定画布大小，用于后续模板比较。
 
     :param binary_mask: 单通道二值图 (0/255)
@@ -167,8 +167,8 @@ def normalize_mask(
 
     h, w = crop.shape
     scale = symbol_size / max(h, w)
-    new_w = max(1, int(round(w * scale)))
-    new_h = max(1, int(round(h * scale)))
+    new_w = max(1, round(w * scale))
+    new_h = max(1, round(h * scale))
     resized = cv2.resize(crop, (new_w, new_h), interpolation=cv2.INTER_NEAREST)
 
     canvas = np.zeros((canvas_size, canvas_size), dtype=np.uint8)
@@ -191,7 +191,7 @@ def rotate_mask(mask: np.ndarray, angle: float) -> np.ndarray:
     return cv2.warpAffine(mask, matrix, (w, h), flags=cv2.INTER_NEAREST, borderValue=0)
 
 
-def crop_foreground(mask: np.ndarray) -> Optional[np.ndarray]:
+def crop_foreground(mask: np.ndarray) -> np.ndarray | None:
     """裁剪 mask 到最小外接矩形 (去除全黑边距)。
 
     :param mask: 单通道二值图
@@ -229,14 +229,13 @@ def match_cost(
     for angle in (-60, -45, -30, -20, -10, 10, 20, 30, 45, 60, 90, -90):
         rotated = rotate_mask(query, angle)
         score = float(np.sum(cv2.absdiff(rotated, candidate)) / 255.0)
-        if score < best:
-            best = score
+        best = min(best, score)
     return best
 
 
 def locate_with_template(
     query_mask: np.ndarray, main_mask: np.ndarray
-) -> Tuple[float, Optional[Tuple[int, int]]]:
+) -> tuple[float, tuple[int, int] | None]:
     """在主图二值 mask 中定位查询符号的位置 (多尺度 + 旋转模板匹配)。
 
     :param query_mask: 提示图中单个符号的原始二值 mask
@@ -265,8 +264,8 @@ def locate_with_template(
     angles = range(-90, 91, 10)
 
     for scale in scales:
-        new_w = max(8, int(round(qw * scale)))
-        new_h = max(8, int(round(qh * scale)))
+        new_w = max(8, round(qw * scale))
+        new_h = max(8, round(qh * scale))
         base = cv2.resize(query_crop, (new_w, new_h), interpolation=cv2.INTER_NEAREST)
 
         for angle in angles:
@@ -298,7 +297,7 @@ def locate_with_template(
 
 def _extract_query_templates(
     prompt_img: np.ndarray,
-) -> Tuple[List[Optional[np.ndarray]], List[np.ndarray]]:
+) -> tuple[list[np.ndarray | None], list[np.ndarray]]:
     """从提示图 (顶部灰色 3 格题目条) 提取 3 个模板和原始 mask。
 
     :param prompt_img: BGR 格式的提示图 (包含顶部灰色条和下方箭头等)
@@ -330,8 +329,8 @@ def _extract_query_templates(
     strip_roi_gray = cv2.cvtColor(strip_roi, cv2.COLOR_BGR2GRAY)
     query_cells = np.array_split(strip_roi_gray, 3, axis=1)
 
-    query_templates: List[Optional[np.ndarray]] = []
-    query_raw_masks: List[np.ndarray] = []
+    query_templates: list[np.ndarray | None] = []
+    query_raw_masks: list[np.ndarray] = []
     for cell in query_cells:
         _, cell_bw = cv2.threshold(
             cell, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU
@@ -347,7 +346,7 @@ def _extract_query_templates(
     return query_templates, query_raw_masks
 
 
-def _extract_main_candidates(main_img: np.ndarray) -> Tuple[List[dict], np.ndarray]:
+def _extract_main_candidates(main_img: np.ndarray) -> tuple[list[dict], np.ndarray]:
     """从主图提取所有候选符号及其归一化特征。
 
     :param main_img: BGR 格式的主图 (包含多个可点击符号)
@@ -371,7 +370,7 @@ def _extract_main_candidates(main_img: np.ndarray) -> Tuple[List[dict], np.ndarr
     num_labels, labels, stats, centroids = cv2.connectedComponentsWithStats(
         symbol_bw, connectivity=8
     )
-    candidates: List[dict] = []
+    candidates: list[dict] = []
     for i in range(1, num_labels):
         x, y, w, h, area = stats[i]
         if area < 150 or area > 6000:
@@ -404,7 +403,7 @@ def _extract_main_candidates(main_img: np.ndarray) -> Tuple[List[dict], np.ndarr
 
 def detect_points(
     prompt_img: np.ndarray, main_img: np.ndarray
-) -> Tuple[List[Optional[Tuple[int, int]]], List[dict]]:
+) -> tuple[list[tuple[int, int] | None], list[dict]]:
     """识别点选验证码的点击顺序。
 
     :param prompt_img: BGR 格式的提示图 (顶部显示 3 个待匹配符号)
@@ -428,8 +427,8 @@ def detect_points(
         return [None, None, None], candidates
 
     used: set[int] = set()
-    ordered_points: List[Optional[Tuple[int, int]]] = []
-    base_scores: List[float] = []
+    ordered_points: list[tuple[int, int] | None] = []
+    base_scores: list[float] = []
 
     # 第一轮: 粗匹配 — 归一化模板 + 旋转搜索
     for template in query_templates:
@@ -494,8 +493,8 @@ def detect_points(
 
 def render_debug(
     main_img: np.ndarray,
-    ordered_points: List[Optional[Tuple[int, int]]],
-    candidates: List[dict],
+    ordered_points: list[tuple[int, int] | None],
+    candidates: list[dict],
 ) -> np.ndarray:
     """在主图上绘制候选框和识别结果，用于可视化调试。
 
@@ -571,7 +570,7 @@ class LoginCaptchaSolver:
     _initialized: bool = False
     _lock = threading.Lock()
     _charset = "0123456789abcdefghijklmnopqrstuvwxyz"
-    _idx_to_char = {i: c for c, i in {c: i for i, c in enumerate(_charset)}.items()}
+    _idx_to_char: ClassVar[dict[int, str]] = {i: c for c, i in {c: i for i, c in enumerate(_charset)}.items()}
     _char_size = 28
 
     @classmethod
@@ -594,15 +593,16 @@ class LoginCaptchaSolver:
                             log.warning(f"验证码模型文件不存在: {model_path}")
                             cls._ocr = False
                         else:
+                            # OpenCV 失败只会抛 cv2.error（模型文件已提前检查存在）
                             cls._ocr = cv2.dnn.readNetFromONNX(str(model_path))
-                    except Exception:
+                    except cv2.error:
                         log.warning("OpenCV DNN 初始化失败，自动验证码识别功能将不可用")
                         cls._ocr = False
                     cls._initialized = True
         return cls._ocr if cls._ocr is not False else None
 
     @classmethod
-    def recognize(cls, image: bytes, log) -> Optional[str]:
+    def recognize(cls, image: bytes, log) -> str | None:
         """用 CNN ONNX 模型识别验证码图片。
 
         :param image: 验证码图片字节 (bytes)
@@ -621,7 +621,7 @@ class LoginCaptchaSolver:
             arr = cv2.imdecode(np.frombuffer(image, np.uint8), cv2.IMREAD_GRAYSCALE)
             if arr is None:
                 return None
-            h, w = arr.shape
+            _, w = arr.shape
             seg_w = w // 4
 
             result = []
@@ -645,7 +645,7 @@ class LoginCaptchaSolver:
             if len(code) == 4:
                 return code
             log.warning("验证码识别结果长度不正确，正在重试")
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 -- cv2/numpy 识别管线，失败返回 None 由调用方重试
             log.error(f"验证码识别异常: {e}")
         return None
 
@@ -680,15 +680,16 @@ def _registry_candidates() -> list[str]:
         return []
     results: list[str] = []
     # Chrome/Edge 通过 App Paths 注册
+    # winreg 仅 Windows 存在，typeshed 按平台裁剪导致 Darwin 下属性不可见
     for hive, subkey in [
-        (winreg.HKEY_CURRENT_USER, r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe"),
-        (winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe"),
-        (winreg.HKEY_CURRENT_USER, r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\msedge.exe"),
-        (winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\msedge.exe"),
+        (winreg.HKEY_CURRENT_USER, r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe"),  # type: ignore[attr-defined]
+        (winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe"),  # type: ignore[attr-defined]
+        (winreg.HKEY_CURRENT_USER, r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\msedge.exe"),  # type: ignore[attr-defined]
+        (winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\msedge.exe"),  # type: ignore[attr-defined]
     ]:
         try:
-            with winreg.OpenKey(hive, subkey) as key:
-                path, _ = winreg.QueryValueEx(key, None)
+            with winreg.OpenKey(hive, subkey) as key:  # type: ignore[attr-defined]
+                path, _ = winreg.QueryValueEx(key, None)  # type: ignore[attr-defined]
                 if path and os.path.isfile(path):
                     results.append(path)
         except (FileNotFoundError, PermissionError):
@@ -696,7 +697,7 @@ def _registry_candidates() -> list[str]:
     return results
 
 
-def detect_browser() -> Optional[str]:
+def detect_browser() -> str | None:
     """自动检测本地已安装的 Chrome/Chromium/Edge 浏览器路径。
 
     按优先级依次检查：
@@ -769,9 +770,9 @@ def detect_browser() -> Optional[str]:
 
 
 def check_browser_health(
-    browser_path: Optional[str] = None,
-    cdp_host: Optional[str] = None,
-    cdp_port: Optional[int] = None,
+    browser_path: str | None = None,
+    cdp_host: str | None = None,
+    cdp_port: int | None = None,
 ) -> str:
     """按优先级检测可用的浏览器：CDP → 用户路径 → 自动检测。
 
@@ -813,6 +814,7 @@ def check_browser_health(
             args,
             capture_output=True,
             timeout=10,
+            check=False,  # 下面手动检查 returncode
         )
         if proc.returncode != 0 or b"<h1>ok</h1>" not in proc.stdout:
             raise RuntimeError(
@@ -837,10 +839,10 @@ class CaptchaHandler:
         user_id: str,
         token: str,
         log,
-        browser_path: Optional[str] = None,
-        cdp_host: Optional[str] = None,
-        cdp_port: Optional[int] = None,
-        debug_dir: Optional[Path] = None,
+        browser_path: str | None = None,
+        cdp_host: str | None = None,
+        cdp_port: int | None = None,
+        debug_dir: Path | None = None,
     ) -> None:
         """初始化验证码处理器。
 
@@ -867,7 +869,7 @@ class CaptchaHandler:
     # ── 浏览器 / 页面构建 ──────────────────────────────
 
     @staticmethod
-    async def _eval_json(tab, expression: str) -> Optional[dict]:
+    async def _eval_json(tab, expression: str) -> dict | None:
         """执行 JS 并将结果转为 Python dict（处理 nodriver 的 RemoteObject 反序列化）。"""
         res: Any = await tab.evaluate(expression, return_by_value=True)
         if isinstance(res, cdp.runtime.RemoteObject):
@@ -991,7 +993,7 @@ class CaptchaHandler:
             await self._ensure_captcha_sdk(tab)
             self.log.info("页面准备完成")
             return browser, tab
-        except asyncio.TimeoutError:
+        except TimeoutError:
             self._quit_browser(browser, "页面构建超时")
             raise RuntimeError("页面加载超时，请检查网络连接")
         except Exception:
@@ -1008,7 +1010,7 @@ class CaptchaHandler:
         """
         await tab.evaluate(_SHOW_JS.replace("__APP_ID__", json.dumps(app_id)))
 
-    async def _wait_captcha_result(self, tab, timeout: float = 120.0) -> Dict[str, str]:
+    async def _wait_captcha_result(self, tab, timeout: float = 120.0) -> dict[str, str]:
         """轮询等待验证码回调结果。
 
         :param tab: 浏览器标签页对象
@@ -1031,7 +1033,7 @@ class CaptchaHandler:
             )
         raise RuntimeError("等待验证码回调超时")
 
-    async def _run_captcha(self, tab, app_id: str) -> Dict[str, str]:
+    async def _run_captcha(self, tab, app_id: str) -> dict[str, str]:
         """触发验证码并阻塞等待用户手动完成。
 
         :param tab: 浏览器标签页对象
@@ -1113,7 +1115,7 @@ class CaptchaHandler:
 
     async def _auto_solve_once(
         self, tab, attempt: int, save_debug: bool
-    ) -> Optional[Dict]:
+    ) -> dict | None:
         """单次自动识别尝试：抓图 → 识别 → 点击 → 提交。
 
         :param tab: 浏览器标签页对象
@@ -1131,7 +1133,7 @@ class CaptchaHandler:
         try:
             main_img = fetch_image(state["bgUrl"])
             prompt_img = fetch_image(state["ansUrl"])
-        except Exception as exc:
+        except (OSError, RuntimeError) as exc:
             self.log.warning(f"自动识别: 抓图失败 - {exc}")
             return None
 
@@ -1199,7 +1201,7 @@ class CaptchaHandler:
 
     async def _auto_solve_captcha(
         self, tab, app_id: str, max_retry: int = 10, save_debug: bool = False
-    ) -> Optional[Dict[str, str]]:
+    ) -> dict[str, str] | None:
         """尝试自动识别点选验证码，失败时自动刷新重试。
 
         :param tab: 浏览器标签页对象 (已加载 SDK)
@@ -1242,16 +1244,16 @@ class CaptchaHandler:
                     if get_child_watcher is not None:
                         watcher = get_child_watcher()
                         watcher.remove_child_handler(pid)
-                except Exception:
+                except (OSError, RuntimeError, KeyError, ValueError):
                     pass
             browser.stop()
             if label:
                 self.log.info(f"已关闭浏览器 ({label})")
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 -- nodriver 停止浏览器可能抛任意异常
             if label:
                 self.log.warning(f"关闭浏览器异常 ({label}): {exc}")
 
-    def handle_exam_captcha(self, user_exam_plan_id: str) -> Dict[str, str]:
+    def handle_exam_captcha(self, user_exam_plan_id: str) -> dict[str, str]:
         """处理考试前的无感验证码（同步版本）。
 
         无感模式：验证码在后台自动完成，无需用户交互，因此使用 headless=True。
@@ -1269,7 +1271,7 @@ class CaptchaHandler:
             "handle_exam_captcha() 无法在已运行的事件循环中调用，请改用 handle_exam_captcha_async()"
         )
 
-    async def handle_exam_captcha_async(self, user_exam_plan_id: str) -> Dict[str, str]:
+    async def handle_exam_captcha_async(self, user_exam_plan_id: str) -> dict[str, str]:
         """处理考试前的无感验证码（异步版本）。"""
         self.log.info("正在处理无感验证码")
         browser, tab = await self._build_page(EXAM_ENTRY_URL, headless=True)
@@ -1280,7 +1282,7 @@ class CaptchaHandler:
         finally:
             self._quit_browser(browser, "无感验证码")
 
-    def handle_course_captcha(self, course_url: Optional[str] = None) -> Dict[str, str]:
+    def handle_course_captcha(self, course_url: str | None = None) -> dict[str, str]:
         """处理课程完成时的图片点选验证码（同步版本）。
 
         流程：先以无头模式自动识别 (10 次重试)，全部失败后再打开可见浏览器让用户手动完成。
@@ -1299,8 +1301,8 @@ class CaptchaHandler:
         )
 
     async def handle_course_captcha_async(
-        self, course_url: Optional[str] = None
-    ) -> Dict[str, str]:
+        self, course_url: str | None = None
+    ) -> dict[str, str]:
         """处理课程完成时的图片点选验证码（异步版本）。"""
         entry_url = course_url or COURSE_ENTRY_URL
 
@@ -1312,7 +1314,7 @@ class CaptchaHandler:
             if result:
                 self.log.success("验证码自动识别成功")
                 return result
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 -- 浏览器自动化异常，回退到手动处理
             self.log.warning(f"自动识别异常，将回退到手动: {exc}")
         finally:
             self._quit_browser(browser, "自动识别")

--- a/client.py
+++ b/client.py
@@ -1,16 +1,16 @@
 import json
 import os
+import re
 import sys
+import threading
 import time
 import webbrowser
 from random import randint
-from typing import Any, Dict
-from urllib.parse import parse_qs, urlparse, urljoin
+from typing import Any
+from urllib.parse import parse_qs, urljoin, urlparse
 from uuid import uuid4
 
 from loguru import logger
-import re
-import threading
 
 from api import WeBanAPI
 from captcha import CaptchaHandler, LoginCaptchaSolver
@@ -147,7 +147,7 @@ def _fetch_text(session, url: str, referer: str | None = None) -> str:
         headers = {"Referer": referer} if referer else None
         resp = session.get(url, timeout=10, headers=headers)
         return resp.text if resp.status_code == 200 else ""
-    except Exception:
+    except OSError:
         return ""
 
 
@@ -164,13 +164,13 @@ class WeBanClient:
         tenant_name: str,
         account: str | None = None,
         password: str | None = None,
-        user: Dict[str, str] | None = None,
+        user: dict[str, str] | None = None,
         log=logger,
         browser_path: str | None = None,
         cdp_host: str | None = None,
         cdp_port: int | None = None,
         debug: bool = False,
-        ai_config: Dict[str, Any] | None = None,
+        ai_config: dict[str, Any] | None = None,
     ) -> None:
         """
         :param tenant_name: 学校全称
@@ -188,6 +188,12 @@ class WeBanClient:
         self.tenant_name = tenant_name.strip()
         self.study_base_time = 20
         self.study_random_upper = 10
+        self.study_force = False
+        self.exam_mode = "true"
+        # 时间预估状态（自适应 EMA）
+        self._eta_course_avg: float | None = None  # 每门课实测平均耗时（秒）
+        self._eta_course_last: dict = {}  # project_id -> (时间戳, 已完成课程数)
+        self._eta_exam_avg: float | None = None  # 每场考试实测平均耗时（秒）
         self.browser_path = browser_path
         self.cdp_host = cdp_host
         self.cdp_port = cdp_port
@@ -227,7 +233,7 @@ class WeBanClient:
         return self._captcha_handler
 
     @staticmethod
-    def _format_duration(seconds: int | float) -> str:
+    def _format_duration(seconds: float) -> str:
         """秒数格式化为 XhXXmXXs / XmXXs / Xs"""
         s = int(seconds)
         h, rem = divmod(s, 3600)
@@ -347,7 +353,7 @@ class WeBanClient:
 
     def get_progress(
         self, user_project_id: str, project_prefix: str | None, output: bool = True
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """获取学习进度
         :param user_project_id: 项目 ID
         :param project_prefix: 日志前缀（如项目名）
@@ -360,16 +366,50 @@ class WeBanClient:
                 self.log.warning(f"{project_prefix} 获取进度失败：{progress}")
             return progress
         data = progress.get("data", {})
-        required = data["requiredNum"] - data["requiredFinishedNum"]
-        optional = data["optionalNum"] - data["optionalFinishedNum"]
-        push = data["pushNum"] - data["pushFinishedNum"]
-        eta = max(
-            0,
-            int(
-                (self.study_base_time + self.study_random_upper / 2)
-                * (required + optional + push)
-            ),
+        if self.study_force:
+            # force 模式会重新学习所有课程，剩余量按总数计算
+            required = data["requiredNum"]
+            optional = data["optionalNum"]
+            push = data["pushNum"]
+        else:
+            required = data["requiredNum"] - data["requiredFinishedNum"]
+            optional = data["optionalNum"] - data["optionalFinishedNum"]
+            push = data["pushNum"] - data["pushFinishedNum"]
+        exam_left = data["examNum"] - data["examFinishedNum"]
+
+        # 自适应每课耗时：相邻两次进度查询之间每完成 n 门课，实测一次并更新 EMA
+        finished = (
+            data["requiredFinishedNum"]
+            + data["pushFinishedNum"]
+            + data["optionalFinishedNum"]
         )
+        now = time.time()
+        last = self._eta_course_last.get(user_project_id)
+        if last is not None and finished >= last[1]:
+            dt = now - last[0]
+            n = finished - last[1]
+            # 间隔超过 15 分钟视为中断/卡死；单课超过 5 分钟视为异常（卡验证码等），均不采纳
+            if n > 0 and 0 < dt <= 900:
+                per_course = dt / n
+                if per_course <= 300:
+                    if self._eta_course_avg is None:
+                        self._eta_course_avg = per_course
+                    else:
+                        self._eta_course_avg = (
+                            0.7 * self._eta_course_avg + 0.3 * per_course
+                        )
+        self._eta_course_last[user_project_id] = (now, finished)
+
+        # 每门课：等待时长理论均值 + 固定开销（翻页 step 发送/课后习题/完课 API 等）
+        course_est = self._eta_course_avg or (
+            self.study_base_time + self.study_random_upper / 2 + 3
+        )
+        eta = course_est * (required + optional + push)
+        # 每场考试：默认 50 题 × 每题 4.5s + 固定开销 ≈ 4 分钟（有实测后自动替换）
+        if exam_left > 0 and self.exam_mode != "false":
+            exam_est = self._eta_exam_avg or (50 * 4.5 + 15)
+            eta += exam_est * exam_left
+        eta = max(0, int(eta))
         if output:
             eta_str = self._format_duration(eta)
             self.log.info(
@@ -382,7 +422,7 @@ class WeBanClient:
 
     # ---- login --------------------------------------------------------------
 
-    def login(self) -> Dict | None:
+    def login(self) -> dict | None:
         """登录并获取 token
 
         重试策略：前 10 次尝试用 CNN 模型自动识别验证码，
@@ -417,7 +457,7 @@ class WeBanClient:
                 )
                 try:
                     os.remove(captcha_path)
-                except Exception:
+                except OSError:
                     pass
             res = self.api.login(verify_code, int(verify_time))
             if res.get("detailCode") == "67":
@@ -452,6 +492,7 @@ class WeBanClient:
         )
 
         force_restudy = study_mode == "force"
+        self.study_force = force_restudy
 
         answers_json = self._load_answers_json(warn_on_fail=True)
 
@@ -561,9 +602,7 @@ class WeBanClient:
         raw = str(res.get("raw", ""))
         if detail in {"10018", "701"}:
             return True
-        if "行为存在异常" in msg or "Account locked" in raw or "Account locked" in msg:
-            return True
-        return False
+        return ("行为存在异常" in msg or "Account locked" in raw or "Account locked" in msg)
 
     def _study_one_course(
         self,
@@ -701,9 +740,7 @@ class WeBanClient:
         res = self._finish_course(course, task, query, course_url, unique_no)
         if res.get("code", "-1") != "0":
             self.log.error(f"{course_prefix} 完成失败：{res}")
-            if self._is_account_blocked(res):
-                return False
-            return True
+            return not self._is_account_blocked(res)
 
         self.log.success(f"{course_prefix} 完成")
         return True
@@ -759,7 +796,7 @@ class WeBanClient:
                     return check_res
                 self.log.success("课程验证码校验通过")
                 finish_kwargs["token"] = check_res.get("data", "")
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 -- 浏览器自动化可能抛任意异常，降级为完成失败
                 self.log.error(f"课程验证码处理异常: {e}")
                 return {"code": "-1"}
         return self.api.finish_by_token(course["userCourseId"], **finish_kwargs)
@@ -795,6 +832,7 @@ class WeBanClient:
         except (ValueError, IndexError):
             question_base_time = 3
             question_random_upper = 3
+        self.exam_mode = exam_mode
 
         answers_json = self._load_answers_json()
 
@@ -836,12 +874,13 @@ class WeBanClient:
                 pass_score = plan.get("passScore", 0)
 
                 # ── 已考过的考试，显示历史成绩 ──
+                full_score = 100
                 if exam_finish_num > 0:
                     try:
                         pp = self.api.exam_prepare_paper(plan["id"])
                         full_score = pp.get("data", {}).get("paperScore", 100)
-                    except Exception:
-                        full_score = 100
+                    except OSError:
+                        pass
                     self.log.info(
                         f"{plan_name} 已考过 {exam_finish_num} 次，"
                         f"最高 {exam_score}/{full_score}（及格线 {pass_score}）"
@@ -860,11 +899,13 @@ class WeBanClient:
                     self.log.info(f"{plan_name} 已及格 ({exam_score}分 >= {pass_score}分)，跳过")
                     continue
 
-                # perfect 模式：已满分则跳过
-                if exam_mode == "perfect" and exam_finish_num > 0:
-                    if exam_score >= full_score:
-                        self.log.info(f"{plan_name} 已满分 ({exam_score}分)，跳过")
-                        continue
+                if (
+                    exam_mode == "perfect"
+                    and exam_finish_num > 0
+                    and exam_score >= full_score
+                ):
+                    self.log.info(f"{plan_name} 已满分 ({exam_score}分)，跳过")
+                    continue
 
                 # perfect 模式：只剩 1 次机会时，检查题库是否能全覆盖
                 if exam_mode == "perfect" and exam_odd_num <= 1:
@@ -900,6 +941,7 @@ class WeBanClient:
                 )
 
                 # 无感验证码
+                plan_start_ts = time.time()
                 try:
                     captcha_result = self.captcha_handler.handle_exam_captcha(
                         user_exam_plan_id
@@ -913,7 +955,7 @@ class WeBanClient:
                         self.log.error(f"无感验证码校验失败：{check_res}")
                         continue
                     self.log.success("无感验证码校验通过")
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001 -- 浏览器自动化可能抛任意异常
                     self.log.error(f"无感验证码处理异常: {e}")
                     continue
 
@@ -947,12 +989,11 @@ class WeBanClient:
                 )
 
                 # perfect 模式：匹配率不足且 random_answer=False 时警告
-                if exam_mode == "perfect" and match_rate < 100:
-                    if not random_answer:
-                        self.log.warning(
-                            f"题库匹配率 {match_rate:.1f}% 不足 100%，"
-                            f"perfect 模式下手动作答可能存在风险"
-                        )
+                if exam_mode == "perfect" and match_rate < 100 and not random_answer:
+                    self.log.warning(
+                        f"题库匹配率 {match_rate:.1f}% 不足 100%，"
+                        f"perfect 模式下手动作答可能存在风险"
+                    )
 
                 # 检查提交匹配率
                 if match_rate < exam_submit_match_rate and not random_answer:
@@ -1087,12 +1128,22 @@ class WeBanClient:
                 self.log.success(
                     f"试卷提交成功，考试完成，成绩：{submit_res['data']['score']} 分"
                 )
+                self._update_exam_eta(time.time() - plan_start_ts)
+
+    def _update_exam_eta(self, elapsed: float) -> None:
+        """用实测考试耗时更新每场考试的自适应估计（EMA）"""
+        if elapsed <= 0:
+            return
+        if self._eta_exam_avg is None:
+            self._eta_exam_avg = elapsed
+        else:
+            self._eta_exam_avg = 0.7 * self._eta_exam_avg + 0.3 * elapsed
 
     # ---- item.js parsing ----------------------------------------------------
 
     def parse_item_js(
         self, course_code: str, course_url: str | None = None
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """解析课程 JS，检测是否使用 apinext 并提取 nonstrMap/total_step。
 
         关键判断：HTML 是否加载 apicenext.js。
@@ -1170,7 +1221,7 @@ class WeBanClient:
                     parts.append(f"+{extra_steps}题")
                 result["total_step_source"] = " ".join(parts)
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 -- 解析边界，尽力而为，失败返回默认结构
             self.log.warning(f"解析课程 JS 失败：{e}")
         return result
 
@@ -1181,7 +1232,7 @@ class WeBanClient:
         user_course_id: str,
         course_id: str,
         user_project_id: str,
-        nonstr_map: Dict[int, str],
+        nonstr_map: dict[int, str],
         total_step: int,
         unique_no: str = "",
         finish: int = 2,
@@ -1230,7 +1281,7 @@ class WeBanClient:
                         self.log.warning(
                             f"apinext [{step}/{total_step}] 返回异常：{resp}"
                         )
-                except Exception as e:
+                except OSError as e:
                     self.log.warning(f"apinext [{step}/{total_step}] 失败：{e}")
         else:
             if step_delay:
@@ -1249,7 +1300,7 @@ class WeBanClient:
                 if not resp.get("success"):
                     self.log.warning(f"apinext 完成请求返回异常：{resp}")
                 self.log.info(f"apinext 完成标记 step={total_step + 1} finish=1 已发送")
-            except Exception as e:
+            except OSError as e:
                 self.log.warning(f"apinext 完成请求失败：{e}")
         return unique_no
 
@@ -1273,7 +1324,7 @@ class WeBanClient:
     def _answer_question(
         self,
         question: dict,
-        answers_json: Dict,
+        answers_json: dict,
         course_id: str,
         save_func,
         source: str,
@@ -1444,7 +1495,7 @@ class WeBanClient:
                 content = res_data["choices"][0]["message"]["content"].strip()
                 break
 
-            except Exception as e:
+            except (OSError, ValueError, KeyError, IndexError, TypeError) as e:
                 if attempt < max_retries:
                     wait = attempt * 2
                     self.log.warning(

--- a/main.py
+++ b/main.py
@@ -4,13 +4,13 @@ import sys
 import threading
 import tomllib
 import traceback
-from concurrent.futures import as_completed, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import requests
 from loguru import logger
 
-from client import WeBanClient
 from captcha import check_browser_health
+from client import WeBanClient
 
 
 def _resolve_version() -> str:
@@ -35,7 +35,7 @@ def _resolve_version() -> str:
         from importlib.metadata import version as _dist_version
 
         return _dist_version("weban")
-    except Exception:
+    except ImportError:  # PackageNotFoundError 是其子类，统一回退 unknown
         return "unknown"
 
 
@@ -99,7 +99,7 @@ def open_editor(path: str):
     try:
         print("编辑完成后按回车键继续...", flush=True)
         input()
-    except Exception:
+    except EOFError:  # stdin 关闭（如管道执行）时直接结束
         pass
 
 
@@ -127,7 +127,7 @@ def load_config() -> dict:
                 f.write(resp.text)
             logger.success(f"远程模板已下载到 {config_path}")
             downloaded = True
-        except Exception as e:
+        except OSError as e:
             logger.error(f"下载远程模板失败: {e}")
 
         if not downloaded and os.path.exists(config_example_path):
@@ -276,6 +276,7 @@ def run_account(
                 study_mode, study_mode
             )
             log.info(f"开始学习 (模式: {mode_desc})")
+            client.exam_mode = exam_mode  # 进度预估需要知道考试是否计入
             client.run_study(study_time, study_mode)
         else:
             log.info("学习模式已关闭，跳过所有学习任务")
@@ -315,7 +316,7 @@ def run_account(
     except ValueError as e:
         log.error(f"参数错误: {e}")
         return False
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 -- 入口兜底，任何未预期异常都记录并返回失败
         log.error(f"运行失败: {e}")
         traceback.print_exc(file=sys.stderr)
         return False
@@ -447,7 +448,7 @@ if __name__ == "__main__":
                             success_count += 1
                         else:
                             failed_count += 1
-                    except Exception as e:
+                    except Exception as e:  # noqa: BLE001 -- 线程结果可能抛任意异常
                         logger.error(f"[账号 {idx + 1}] 线程执行异常: {e}")
                         failed_count += 1
 
@@ -471,11 +472,11 @@ if __name__ == "__main__":
 
     except KeyboardInterrupt:
         print("用户终止")
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 -- 入口兜底
         logger.error(f"运行失败: {e}")
         traceback.print_exc(file=sys.stderr)
 
     try:
         input("按回车键退出")
-    except Exception:
+    except EOFError:
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,8 @@ dev = [
     "pyright>=1.1.409",
     "ruff>=0.15.15",
 ]
+
+[tool.pyright]
+pythonVersion = "3.12"
+venvPath = "."
+venv = ".venv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "weban"
-version = "3.8.6"
+version = "3.8.7"
 description = "auto finish weiban"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"


### PR DESCRIPTION
## 变更内容

### 1. 时间预估优化（基于 logs/ 实测数据）

回放 4344 条进度日志、1659 个课程段、67 场考试后发现旧 ETA 系统性低估：

| 指标 | 旧版 | 新版 |
|---|---|---|
| 平均偏差 | -40.2%（严重低估） | -0.6% |
| 平均绝对误差 | 40.2% | 5.4% |
| 误差>30% 占比 | 62% | 1% |

- **自适应每课耗时**：相邻两次进度查询间实测每课耗时，EMA(α=0.3) 平滑，排除 >15min 中断与单课 >5min 异常样本；回退值 = 等待时长理论均值 + 固定开销（翻页 step/课后习题/完课 API）
- **考试计入 ETA**：剩余考试 × 每场耗时（默认 50 题 ≈ 240s，考试完成后用实测 EMA 更新）；`exam_mode=false` 时不计入
- **force 模式修正**：按课程总数预估（此前剩余数恒为 0，ETA 恒显示 0s）

### 2. 修复 ruff 148 个错误（全部清零）

- UP006/UP045/UP035/UP041 等自动修复 111 个
- BLE001/S110：能窄化的窄化（`OSError`/`EOFError`/`cv2.error`/`ImportError` 等），浏览器自动化等真正需要兜底的边界加 `# noqa: BLE001` 并注明原因
- RUF012 类属性加 `ClassVar`、RUF046 去除冗余 `int()`、SIM102/103 合并条件等

### 3. 修复 pyright 14 个错误（全部清零）

- `pyproject.toml` 增加 `[tool.pyright]`，指定 pythonVersion 3.12 + 项目 venv（此前误用全局 3.14 导致依赖无法解析）
- `winreg` 属性访问加 `type: ignore[attr-defined]`（typeshed 按平台裁剪，Darwin 下模块体为空，仅 Windows 分支使用）
- `full_score` 未绑定、`PackageNotFoundError` 引用等问题

## 验证

- `ruff check .` → All checks passed
- `pyright` → 0 errors
- `python -m py_compile` 全部通过