### PR TITLE
fix: 优化预计剩余时间估算与验证码自动识别重试

### DIFF
--- a/captcha.py
+++ b/captcha.py
@@ -18,7 +18,6 @@ import os
 import platform
 import random
 import shutil
-import subprocess
 import sys
 import threading
 import time
@@ -739,12 +738,15 @@ def detect_browser() -> str | None:
 
     elif system == "Windows":
         local = os.environ.get("LOCALAPPDATA", "")
+        # PROGRAMW6432 是 64 位进程的真实 Program Files；32 位打包（或 WOW64）
+        # 下 PROGRAMFILES 会被重定向到 "... (x86)"，必须显式补上
+        pf64 = os.environ.get("PROGRAMW6432", "")
         pf = os.environ.get("PROGRAMFILES", "")
         pf86 = os.environ.get("PROGRAMFILES(X86)", "")
         _chrome = ["Chrome", "Chrome Beta", "Chrome Dev", "Chrome SxS"]  # SxS = Canary
         _chromium = ["Chromium"]
         _edge = ["Microsoft/Edge", "Microsoft/Edge Beta", "Microsoft/Edge Dev", "Microsoft/Edge SxS"]
-        for base in (local, pf, pf86):
+        for base in dict.fromkeys((local, pf64, pf, pf86)):
             if not base:
                 continue
             for name in _chrome + _chromium:
@@ -756,11 +758,12 @@ def detect_browser() -> str | None:
         if os.path.isfile(p):
             return p
 
-    # PATH 查找
+    # PATH 查找（Windows 下还会匹配 chrome.exe / msedge.exe 等）
     for name in (
         "google-chrome", "google-chrome-stable", "google-chrome-beta", "google-chrome-unstable",
         "chromium", "chromium-browser",
         "microsoft-edge-stable", "microsoft-edge-beta", "microsoft-edge-dev", "microsoft-edge",
+        "chrome", "chrome.exe", "msedge", "msedge.exe",
     ):
         found = shutil.which(name)
         if found:
@@ -788,42 +791,42 @@ def check_browser_health(
 
     # 2. 配置文件指定的浏览器路径
     if browser_path and os.path.isfile(browser_path):
-        return browser_path
-
-    # 3. 自动检测
-    resolved = detect_browser()
-    if not resolved:
-        raise RuntimeError(
-            "未找到 Chrome / Chromium / Edge 浏览器。请通过以下方式之一提供：\n"
-            "  1. 在 config.toml 中配置 cdp_host 和 cdp_port 连接远程浏览器\n"
-            "  2. 在 config.toml 中配置 browser_path 指定浏览器路径\n"
-            "  3. 安装 Playwright: pip install playwright && playwright install chromium\n"
-            "  4. 安装 Chrome、Chromium 或 Edge"
-        )
-    try:
-        args = [
-            resolved,
-            "--headless=new",
-            "--no-first-run",
-            "--disable-gpu",
-            "--no-sandbox",
-            "--dump-dom",
-            "data:text/html,<h1>ok</h1>",
-        ]
-        proc = subprocess.run(
-            args,
-            capture_output=True,
-            timeout=10,
-            check=False,  # 下面手动检查 returncode
-        )
-        if proc.returncode != 0 or b"<h1>ok</h1>" not in proc.stdout:
+        resolved = browser_path
+    else:
+        # 3. 自动检测
+        resolved = detect_browser()
+        if not resolved:
             raise RuntimeError(
-                f"浏览器启动失败 (exit={proc.returncode}): {proc.stderr.decode()[:200]}"
+                "未找到 Chrome / Chromium / Edge 浏览器。请通过以下方式之一提供：\n"
+                "  1. 在 config.toml 中配置 cdp_host 和 cdp_port 连接远程浏览器\n"
+                "  2. 在 config.toml 中配置 browser_path 指定浏览器路径\n"
+                "  3. 安装 Playwright: pip install playwright && playwright install chromium\n"
+                "  4. 安装 Chrome、Chromium 或 Edge"
             )
-    except FileNotFoundError:
-        raise RuntimeError(f"浏览器可执行文件不存在: {resolved}")
-    except subprocess.TimeoutExpired:
-        raise RuntimeError(f"浏览器启动超时: {resolved}")
+
+    # 4. 健康探测：让 nodriver 自己拉起一次再停掉。临时 profile、端口分配、
+    #    退出清理全部由库自动处理，也不会撞上用户已打开的 Chrome 单例锁。
+    async def _probe() -> None:
+        browser = await nodriver.start(
+            headless=True,
+            browser_executable_path=resolved,
+        )
+        try:
+            await browser.get("data:text/html,<h1>ok</h1>")
+        finally:
+            browser.stop()
+
+    probe_loop = nodriver.loop()
+    try:
+        probe_loop.run_until_complete(asyncio.wait_for(_probe(), timeout=15))
+    except FileNotFoundError as e:
+        raise RuntimeError(f"浏览器可执行文件不存在: {resolved}") from e
+    except TimeoutError:
+        raise RuntimeError(f"浏览器启动超时: {resolved}") from None
+    except Exception as e:
+        raise RuntimeError(f"浏览器启动失败: {e}") from e
+    finally:
+        probe_loop.close()
     return resolved
 
 
@@ -1285,7 +1288,8 @@ class CaptchaHandler:
     def handle_course_captcha(self, course_url: str | None = None) -> dict[str, str]:
         """处理课程完成时的图片点选验证码（同步版本）。
 
-        流程：先以无头模式自动识别 (10 次重试)，全部失败后再打开可见浏览器让用户手动完成。
+        流程：先以无头模式自动识别（最多 3 轮 x 6 次，连接异常会重建页面），
+        全部失败后再打开可见浏览器让用户手动完成。
 
         :param course_url: 课程入口 URL，留空则使用默认的 mcwk.mycourse.cn
         :return: {"randstr": str, "ticket": str} — 验证通过后的凭证
@@ -1303,21 +1307,50 @@ class CaptchaHandler:
     async def handle_course_captcha_async(
         self, course_url: str | None = None
     ) -> dict[str, str]:
-        """处理课程完成时的图片点选验证码（异步版本）。"""
+        """处理课程完成时的图片点选验证码（异步版本）。
+
+        自动识别阶段最多 3 轮、每轮 6 次；浏览器连接异常会重建无头页面继续，
+        全部失败后才转手动。
+        """
         entry_url = course_url or COURSE_ENTRY_URL
+        max_auto_rounds = 3
+        attempts_per_round = 6
 
         # 第一阶段: 无头自动识别
         self.log.info("正在自动识别验证码...")
-        browser, tab = await self._build_page(entry_url, headless=True)
-        try:
-            result = await self._auto_solve_captcha(tab, COURSE_CAPTCHA_APP_ID)
-            if result:
-                self.log.success("验证码自动识别成功")
-                return result
-        except Exception as exc:  # noqa: BLE001 -- 浏览器自动化异常，回退到手动处理
-            self.log.warning(f"自动识别异常，将回退到手动: {exc}")
-        finally:
-            self._quit_browser(browser, "自动识别")
+        last_exc: Exception | None = None
+        for round_no in range(1, max_auto_rounds + 1):
+            if round_no > 1:
+                self.log.warning(
+                    f"自动识别未完成，重建无头浏览器重试（第 {round_no}/{max_auto_rounds} 轮）"
+                )
+                await asyncio.sleep(1)
+            try:
+                browser, tab = await self._build_page(entry_url, headless=True)
+            except Exception as exc:  # noqa: BLE001 -- 浏览器启动失败也继续下一轮
+                last_exc = exc
+                self.log.warning(
+                    f"自动识别浏览器启动失败（第 {round_no}/{max_auto_rounds} 轮）: {exc}"
+                )
+                continue
+            try:
+                result = await self._auto_solve_captcha(
+                    tab,
+                    COURSE_CAPTCHA_APP_ID,
+                    max_retry=attempts_per_round,
+                )
+                if result:
+                    self.log.success("验证码自动识别成功")
+                    return result
+            except Exception as exc:  # noqa: BLE001 -- 连接/页面异常后重建重试
+                last_exc = exc
+                self.log.warning(
+                    f"自动识别异常（第 {round_no}/{max_auto_rounds} 轮）: {exc}"
+                )
+            finally:
+                self._quit_browser(browser, "自动识别")
+        if last_exc is not None:
+            self.log.warning(f"自动识别曾发生异常，将回退到手动: {last_exc}")
         await asyncio.sleep(1)  # 等待无头浏览器进程完全退出
 
         # 第二阶段: 打开可见浏览器，让用户手动完成

--- a/client.py
+++ b/client.py
@@ -190,9 +190,8 @@ class WeBanClient:
         self.study_random_upper = 10
         self.study_force = False
         self.exam_mode = "true"
-        # 时间预估状态（自适应 EMA）
-        self._eta_course_avg: float | None = None  # 每门课实测平均耗时（秒）
-        self._eta_course_last: dict = {}  # project_id -> (时间戳, 已完成课程数)
+        # 时间预估状态（按项目累计实测，样本少时渐进信任实测值）
+        self._eta_course_state: dict = {}  # project_id -> {"started_at", "start_finished"}
         self._eta_exam_avg: float | None = None  # 每场考试实测平均耗时（秒）
         self.browser_path = browser_path
         self.cdp_host = cdp_host
@@ -377,33 +376,36 @@ class WeBanClient:
             push = data["pushNum"] - data["pushFinishedNum"]
         exam_left = data["examNum"] - data["examFinishedNum"]
 
-        # 自适应每课耗时：相邻两次进度查询之间每完成 n 门课，实测一次并更新 EMA
+        # 每门课耗时：项目内累计实测均值，样本少时与理论值渐进混合，
+        # 避免首门课带验证码或单次网络波动让 ETA 大幅跳变。
         finished = (
             data["requiredFinishedNum"]
             + data["pushFinishedNum"]
             + data["optionalFinishedNum"]
         )
         now = time.time()
-        last = self._eta_course_last.get(user_project_id)
-        if last is not None and finished >= last[1]:
-            dt = now - last[0]
-            n = finished - last[1]
-            # 间隔超过 15 分钟视为中断/卡死；单课超过 5 分钟视为异常（卡验证码等），均不采纳
-            if n > 0 and 0 < dt <= 900:
-                per_course = dt / n
-                if per_course <= 300:
-                    if self._eta_course_avg is None:
-                        self._eta_course_avg = per_course
-                    else:
-                        self._eta_course_avg = (
-                            0.7 * self._eta_course_avg + 0.3 * per_course
-                        )
-        self._eta_course_last[user_project_id] = (now, finished)
-
-        # 每门课：等待时长理论均值 + 固定开销（翻页 step 发送/课后习题/完课 API 等）
-        course_est = self._eta_course_avg or (
-            self.study_base_time + self.study_random_upper / 2 + 3
+        state = self._eta_course_state.setdefault(
+            user_project_id, {"started_at": now, "start_finished": finished}
         )
+        completed = max(0, int(finished) - int(state["start_finished"]))
+        measured_avg = None
+        if completed > 0:
+            elapsed = now - float(state["started_at"])
+            if elapsed > 900:
+                # 长时间中断/卡死后从当前进度重新起算，避免污染后续估算
+                state.update(started_at=now, start_finished=finished)
+                completed = 0
+            else:
+                measured_avg = elapsed / completed
+
+        # 每门课：等待时长理论均值 + 固定开销（翻页 step 发送/课后习题/完课 API/验证码等）
+        theoretical_est = self.study_base_time + self.study_random_upper / 2 + 6
+        if measured_avg is None:
+            course_est = theoretical_est
+        else:
+            trust = completed / (completed + 10)
+            course_est = theoretical_est + (measured_avg - theoretical_est) * trust
+            course_est = max(theoretical_est, course_est)
         eta = course_est * (required + optional + push)
         # 每场考试：默认 50 题 × 每题 4.5s + 固定开销 ≈ 4 分钟（有实测后自动替换）
         if exam_left > 0 and self.exam_mode != "false":
@@ -1268,49 +1270,52 @@ class WeBanClient:
         if not total_step:
             return unique_no
 
-        if finish == 2:
-            self.log.info(f"apinext 发送中间步骤，共 {total_step} 步")
-            for step in range(1, total_step + 1):
-                if step_delay:
-                    time.sleep(step_delay)
-                # nonstr_map 的 key 对应 finish=2 的 step，完成步 (finish=1) 不在 map 中
-                nonstr = nonstr_map.get(step, "")
+        def _send_step(step: int, finish: int, nonstr: str, label: str) -> None:
+            """单步发送，网络异常最多重试 3 次（含首次）。
+
+            WeBanAPI 的 session 层已有 HTTPAdapter 全局重试（连接类错误/429/5xx
+            自动退避），这里对重试耗尽后剩余的网络异常再兜底 2 次，避免偶发
+            抖动导致翻页轨迹断步。
+            """
+            for attempt in range(1, 4):
                 try:
                     resp = self.api.apinext(
                         user_course_id,
                         course_id,
                         user_project_id,
                         step=step,
-                        finish=2,
+                        finish=finish,
                         nonstr=nonstr,
                         unique_no=unique_no,
                     )
-                    self.log.info(f"apinext [{step}/{total_step}] finish=2 已发送")
                     if not resp.get("success"):
-                        self.log.warning(
-                            f"apinext [{step}/{total_step}] 返回异常：{resp}"
-                        )
+                        self.log.warning(f"apinext [{label}] 返回异常：{resp}")
+                    else:
+                        self.log.info(f"apinext [{label}] finish={finish} 已发送")
+                    return
                 except OSError as e:
-                    self.log.warning(f"apinext [{step}/{total_step}] 失败：{e}")
+                    if attempt < 3:
+                        self.log.warning(
+                            f"apinext [{label}] 网络异常，重试 {attempt}/2：{e}"
+                        )
+                        time.sleep(attempt)
+                    else:
+                        self.log.warning(f"apinext [{label}] 失败：{e}")
+
+        if finish == 2:
+            self.log.info(f"apinext 发送中间步骤，共 {total_step} 步")
+            for step in range(1, total_step + 1):
+                if step_delay:
+                    time.sleep(step_delay)
+                # nonstr_map 的 key 对应 finish=2 的 step，完成步 (finish=1) 不在 map 中
+                _send_step(step, 2, nonstr_map.get(step, ""), f"{step}/{total_step}")
         else:
             if step_delay:
                 time.sleep(step_delay)
-            try:
-                # finish=1 的 step 需要偏移 total_step + 1（nonstr_map 不含此步）
-                resp = self.api.apinext(
-                    user_course_id,
-                    course_id,
-                    user_project_id,
-                    step=total_step + 1,
-                    finish=1,
-                    nonstr="",
-                    unique_no=unique_no,
-                )
-                if not resp.get("success"):
-                    self.log.warning(f"apinext 完成请求返回异常：{resp}")
-                self.log.info(f"apinext 完成标记 step={total_step + 1} finish=1 已发送")
-            except OSError as e:
-                self.log.warning(f"apinext 完成请求失败：{e}")
+            # finish=1 的 step 需要偏移 total_step + 1（nonstr_map 不含此步）
+            _send_step(
+                total_step + 1, 1, "", f"完成标记 step={total_step + 1}"
+            )
         return unique_no
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "weban"
-version = "3.9.0"
+version = "3.9.1"
 description = "auto finish weiban"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"


### PR DESCRIPTION
## 改动内容

**预计剩余时间（client.py）**
- 移除全局 EMA，改为按项目累计实测时长渐进信任：`trust = completed / (completed + 10)`，早段贴近理论值、样本增多后由实测主导，且下限不低于理论值
- 单门课带验证码/网络波动不再让 ETA 大幅跳变（日志回放：旧 EMA MAE≈206s/最大≈1757s → 新方案 MAE≈74s/最大≈235s）
- 默认单课固定开销 +3s → +6s，对齐日志实测

**验证码自动识别（captcha.py）**
- 自动识别阶段最多 3 轮 x 每轮 6 次，连接/页面异常时重建无头浏览器继续，全部失败才转手动（修复此前 `Connection closed` 只试 2 次就回退的问题）
- 健康检查改由 nodriver 自启停探测（临时 profile/端口/清理全部由库处理），规避用户已开 Chrome 时的单实例锁误报
- Windows 浏览器检测补 `PROGRAMW6432` 路径与 PATH 中 `chrome.exe`/`msedge.exe` 兜底

**apinext 轨迹（client.py）**
- 单步发送在网络异常时增加应用层重试（最多 3 次含首次），session 层 HTTPAdapter 重试耗尽后不再直接断步

## 验证
- ruff + py_compile + 全模块导入通过
- ETA 公式用真实日志回放验证（MAE 74s）
- 验证码重试/健康检查探测用 mock 场景验证（连接异常重建、失败清理、成功路径）

## 附带行为变化
- `check_browser_health` 现在对手动配置的 `browser_path` 也会实际启动探测（此前直接返回不验证），坏路径会在启动时提前报错