### PR TITLE
fix: Token 失效立即终止账号等日志改进

### DIFF
--- a/client.py
+++ b/client.py
@@ -284,6 +284,8 @@ class WeBanClient:
                 res = fn()
                 if res.get("code", "-1") != "0":
                     self.log.debug(f"首页{name}返回异常：{res}")
+            except PermissionError:
+                raise  # Token 失效（被顶号等），立即终止该账号
             except OSError as e:  # 网络异常（DNS/连接/SSL）忽略，不影响主流程
                 self.log.debug(f"首页{name}请求失败（网络异常）：{e}")
 
@@ -310,8 +312,12 @@ class WeBanClient:
                     time.sleep(min(min_read, 300))
                 try:
                     self.api.view_must_notice(nid)
+                except PermissionError:
+                    raise  # Token 失效，立即终止该账号
                 except OSError as e:
                     self.log.debug(f"确认必读公告失败（网络异常）：{e}")
+        except PermissionError:
+            raise  # Token 失效，立即终止该账号
         except OSError as e:
             self.log.debug(f"必读公告流程失败（网络异常）：{e}")
 
@@ -321,6 +327,8 @@ class WeBanClient:
             qlist = q.get("data") if isinstance(q.get("data"), list) else []
             if q.get("code", "-1") == "0" and qlist:
                 self.log.info(f"存在 {len(qlist)} 个待答问卷（官方会弹窗提示，请前往网页完成）")
+        except PermissionError:
+            raise  # Token 失效，立即终止该账号
         except OSError as e:
             self.log.debug(f"问卷列表请求失败（网络异常）：{e}")
 
@@ -606,6 +614,8 @@ class WeBanClient:
             # 不依赖课程是否加载 apicenext.js
             try:
                 self.api.init_index(task["userProjectId"])
+            except PermissionError:
+                raise  # Token 失效，立即终止该账号
             except OSError as e:  # 网络异常不阻断学习
                 self.log.warning(f"初始化学习索引失败（网络异常）：{e}")
             self.get_progress(task["userProjectId"], project_prefix)
@@ -620,6 +630,8 @@ class WeBanClient:
                     categories = self.api.list_category(
                         task["userProjectId"], choose_type[0]
                     )
+                except PermissionError:
+                    raise  # Token 失效，立即终止该账号
                 except OSError as e:  # 网络异常（DNS/连接/SSL）跳过本分类，不中断整个账号
                     self.log.error(f"获取 {choose_type[1]} 分类失败（网络异常）：{e}")
                     continue
@@ -683,6 +695,8 @@ class WeBanClient:
                                     self.log.warning(
                                         f"{course_prefix}：完课成功但进度未更新，请手动检查"
                                     )
+                        except PermissionError:
+                            raise  # Token 失效，立即终止该账号
                         except OSError as e:
                             # 网络异常（DNS/连接/SSL）跳过本门课程，不中断整个账号；
                             # 未完成的课程下次运行会自动重学
@@ -914,6 +928,8 @@ jupiter_fallback=true 时也补翻页轨迹。再答题，最后完课。
                     return check_res
                 self.log.success("课程验证码校验通过")
                 finish_kwargs["token"] = check_res.get("data", "")
+            except PermissionError:
+                raise  # Token 失效，立即终止该账号
             except Exception as e:  # noqa: BLE001 -- 浏览器自动化可能抛任意异常，降级为完成失败
                 self.log.error(f"课程验证码处理异常: {e}")
                 return {"code": "-1"}
@@ -997,6 +1013,8 @@ jupiter_fallback=true 时也补翻页轨迹。再答题，最后完课。
                     try:
                         pp = self.api.exam_prepare_paper(plan["id"])
                         full_score = pp.get("data", {}).get("paperScore", 100)
+                    except PermissionError:
+                        raise  # Token 失效，立即终止该账号
                     except OSError:
                         pass
                     self.log.info(
@@ -1073,6 +1091,8 @@ jupiter_fallback=true 时也补翻页轨迹。再答题，最后完课。
                         self.log.error(f"无感验证码校验失败：{check_res}")
                         continue
                     self.log.success("无感验证码校验通过")
+                except PermissionError:
+                    raise  # Token 失效，立即终止该账号
                 except Exception as e:  # noqa: BLE001 -- 浏览器自动化可能抛任意异常
                     self.log.error(f"无感验证码处理异常: {e}")
                     continue
@@ -1559,6 +1579,8 @@ jupiter_fallback=true 时也补翻页轨迹。再答题，最后完课。
                     else:
                         self.log.info(f"apinext [{label}] finish={finish} 已发送")
                     return
+                except PermissionError:
+                    raise  # Token 失效，立即终止该账号
                 except OSError as e:
                     if attempt < 3:
                         self.log.warning(

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 import threading
+import time
 import tomllib
 import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -52,6 +53,24 @@ config_path = os.path.join(base_path, "config.toml")
 config_example_path = os.path.join(base_path, "config.example.toml")
 logs_dir = os.path.join(base_path, "logs")
 
+# 本次进程启动时间戳，用于日志文件名区分每次运行（如 20260810-132642）
+run_start_ts = time.strftime("%Y%m%d-%H%M%S")
+
+
+def _log_format_message(record) -> str:
+    """终端 sink 的格式化函数。
+
+    DEBUG 级别的请求/响应详情（含 HTML 页面）带大量换行，转义成单行
+    并限制字数，避免刷屏；其余级别（INFO/SUCCESS/WARNING/ERROR 等）
+    保持消息原样，正常换行不受影响。日志文件 sink 不经过此函数。
+    """
+    if record["level"].name == "DEBUG":
+        msg = record["message"].replace("\n", "\\n").replace("\r", "\\r")
+        if len(msg) > 2000:
+            msg = msg[:2000]
+        record["message"] = msg
+    return log_format  # loguru 会基于修改后的 record 替换占位符
+
 # 远程模板下载地址
 CONFIG_EXAMPLE_URL = (
     "https://gh-proxy.com/https://github.com/hangone/WeBan/raw/refs/heads/main/"
@@ -67,17 +86,17 @@ log_format = (
     "<blue>{extra[account]}</blue>|"
     "<cyan>{message}</cyan>"
 )
-# 终端输出截断超长消息（DEBUG 模式请求/响应详情可能刷屏）；
-# 日志文件使用完整格式，不截断
+# 终端输出转义为单行并截断超长消息（DEBUG 模式请求/响应详情可能刷屏）；
+# 日志文件使用完整格式，不转义、不截断
 logger.add(
     sink=sys.stdout,
     colorize=True,
-    format=log_format.replace("{message}", "{message:.2000}"),
+    format=_log_format_message,
 )
 
 os.makedirs(logs_dir, exist_ok=True)
 logger.add(
-    os.path.join(logs_dir, "weban.log"),
+    os.path.join(logs_dir, f"weban-{run_start_ts}.log"),
     encoding="utf-8",
     format=log_format,
     retention="7 days",
@@ -221,7 +240,9 @@ def run_account(
     # 为该账号创建专属日志文件夹
     account_log_dir = os.path.join(logs_dir, account_name)
     os.makedirs(account_log_dir, exist_ok=True)
-    account_log_path = os.path.join(account_log_dir, "weban.log")
+    account_log_path = os.path.join(
+        account_log_dir, f"weban-{run_start_ts}.log"
+    )
 
     # 添加只属于该账号的日志 sink（debug 请求/响应详情走 DEBUG 级别，需放行）
     account_filter = _make_account_filter(account_name)


### PR DESCRIPTION
## 修复

- Token 失效（403 被顶号）不再被当作网络异常跳过课程空转，立即终止该账号（9 处 except OSError 前置放行 PermissionError）
- 终端日志仅 DEBUG 级别转义换行为单行并限制 2000 字，其余级别保持正常换行；日志文件完整不截断
- 日志文件名带启动时间戳 weban-YYYYMMDD-HHMMSS.log，每次运行独立文件

已用桩测试验证 PermissionError 终止 / OSError 照旧跳过。