### PR TITLE
fix: 模板与题库下载统一 jsDelivr 单源并共用打包版兜底

### DIFF
--- a/api.py
+++ b/api.py
@@ -108,8 +108,11 @@ class LoggingSession:
 
 
 class WeBanAPI:
-    # 题库下载地址
-    ANSWER_URL = "https://gh-proxy.com/https://github.com/hangone/WeBan/raw/refs/heads/main/answer/answer.json"
+    # 题库下载地址（jsDelivr CDN 稳定；gh-proxy 免费公共代理会限流 403，
+    # github 官方 raw 域名在国内不稳定，均不用）
+    ANSWER_URL = (
+        "https://cdn.jsdelivr.net/gh/hangone/WeBan@main/answer/answer.json"
+    )
 
     def __init__(
         self,
@@ -1329,7 +1332,9 @@ class WeBanAPI:
           }
         }
         """
-        return self.session.get(self.ANSWER_URL, timeout=self.timeout).text
+        resp = self.session.get(self.ANSWER_URL, timeout=self.timeout)
+        resp.raise_for_status()
+        return resp.text
 
     def apinext(
         self,

--- a/client.py
+++ b/client.py
@@ -55,6 +55,24 @@ def get_source_str(query: dict) -> str:
     return "WEIBAN"
 
 
+def read_first_existing(paths: list[str]) -> str | None:
+    """按序读取第一个存在的本地文件内容（模板/题库的打包版兜底共用）。
+
+    模板（config.example.toml）与题库（answer.json）的下载都会先尝试
+    jsDelivr 远程源；失败时回退到本地候选文件（打包内置 _MEIPASS 或
+    可执行文件旁），两者共用本函数读取兜底内容。
+    :param paths: 候选路径，按优先级排列（如 bundle 内置优先）
+    :return: 文件文本；全部不存在或不可读返回 None
+    """
+    for path in paths:
+        try:
+            with open(path, encoding="utf-8") as f:
+                return f.read()
+        except OSError:
+            continue
+    return None
+
+
 def _check_code_ok(data: dict, allow_200: bool = True) -> bool:
     """接口业务码是否成功（对齐官方 checkCode）
 
@@ -2012,9 +2030,21 @@ jupiter_fallback=true 时也补翻页轨迹。再答题，最后完课。
                 need_download = True
 
         if need_download:
+            # 与模板下载同构：远程 jsDelivr 失败后回退打包内置/本地文件兜底
             self.log.info("题库不存在或格式错误，正在下载...")
+            try:
+                remote = self.api.download_answer()
+                self.log.success("题库已从远程下载")
+            except Exception as e:  # noqa: BLE001 -- 网络失败不应中断整个账号流程
+                self.log.warning(f"题库下载失败：{e}，回退本地内置题库")
+                remote = read_first_existing(
+                    [bundle_answer_path, answer_path, root_answer_path]
+                )
+                if remote is None:
+                    self.log.warning("本地无可用题库，本次跳过题库同步")
+                    return
             with open(answer_path, "w", encoding="utf-8") as f:
-                f.write(self.api.download_answer())
+                f.write(remote)
             try:
                 with open(answer_path, encoding="utf-8") as f:
                     answers_json = json.load(f)

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ import requests
 from loguru import logger
 
 from captcha import check_browser_health
-from client import WeBanClient
+from client import WeBanClient, read_first_existing
 
 
 def _resolve_version() -> str:
@@ -51,7 +51,12 @@ else:
     bundle_path = base_path
 
 config_path = os.path.join(base_path, "config.toml")
-config_example_path = os.path.join(base_path, "config.example.toml")
+# 模板可能位于: 打包资源目录(_MEIPASS, onefile 解压) / exe 旁 / 源码目录
+# frozen 时 base_path 是 exe 目录而模板在 bundle 里，必须 bundle 优先
+config_example_candidates = [
+    os.path.join(bundle_path, "config.example.toml"),
+    os.path.join(base_path, "config.example.toml"),
+]
 logs_dir = os.path.join(base_path, "logs")
 
 # 本次进程启动时间戳，用于日志文件名区分每次运行（如 20260810-132642）
@@ -74,10 +79,10 @@ def _log_format_message(record) -> str:
     # 必须显式加 \n，否则终端所有日志挤在一行
     return log_format + "\n"  # loguru 会基于修改后的 record 替换占位符
 
-# 远程模板下载地址
+# 远程模板下载地址（jsDelivr CDN 稳定；gh-proxy 免费公共代理会限流 403，
+# github 官方 raw 域名在国内不稳定，均不用）
 CONFIG_EXAMPLE_URL = (
-    "https://gh-proxy.com/https://github.com/hangone/WeBan/raw/refs/heads/main/"
-    "config.example.toml"
+    "https://cdn.jsdelivr.net/gh/hangone/WeBan@main/config.example.toml"
 )
 
 # ── 日志 ──
@@ -214,13 +219,15 @@ def load_config() -> dict:
             logger.success(f"远程模板已下载到 {config_path}")
             downloaded = True
         except OSError as e:
-            logger.error(f"下载远程模板失败: {e}")
+            logger.warning(f"下载远程模板失败 ({CONFIG_EXAMPLE_URL}): {e}")
 
-        if not downloaded and os.path.exists(config_example_path):
-            import shutil
-
-            shutil.copy(config_example_path, config_path)
-            logger.success(f"已从本地模板创建 {config_path}")
+        if not downloaded:
+            local_template = read_first_existing(config_example_candidates)
+            if local_template is not None:
+                with open(config_path, "w", encoding="utf-8") as f:
+                    f.write(local_template)
+                logger.success(f"已从本地模板创建 {config_path}")
+                downloaded = True
 
         if os.path.exists(config_path):
             logger.info("正在打开配置文件，请填写账号信息后保存...")


### PR DESCRIPTION
模板/题库下载源统一为 jsDelivr CDN（gh-proxy 免费代理限流 403、github raw 不稳定）；修复打包版 config 模板 bundle 路径（_MEIPASS）找不到问题；新增 read_first_existing 公共兜底函数，模板与题库共用（bundle 内置 → 本地文件）。

桩测通过（bundle 兜底/无兜底跳过/远程成功），jsDelivr 实测 200。