### PR TITLE
feat: 增设自定义AI请求体的功能

### DIFF
--- a/client.py
+++ b/client.py
@@ -2129,12 +2129,32 @@ jupiter_fallback=true 时也补翻页轨迹。再答题，最后完课。
         payload = {
             "model": model,
             "messages": [{"role": "user", "content": prompt}],
-            "temperature": 0,
-            "response_format": {"type": "json_object"},
+            "temperature": 0
         }
+
+        # 用户自定义 body：兼容单行 JSON 字符串（config.toml）与 dict（TOML 内联表）
+        user_payload = self.ai_config.get("custom_body") or {}
+        if isinstance(user_payload, str):
+            try:
+                user_payload = json.loads(user_payload)
+            except json.JSONDecodeError as e:
+                self.log.error(f"AI 搜题 - [ai].custom_body 不是合法 JSON（{e}），已忽略")
+                user_payload = {}
+        if not isinstance(user_payload, dict):
+            self.log.error("AI 搜题 - [ai].custom_body 必须是 JSON 对象（{...}），已忽略")
+            user_payload = {}
+
+        reserved_keys = ("model", "messages", "temperature") # 禁止用户设置这些body，因为这会和系统内置的产生冲突
 
         url = f"{base_url.rstrip('/')}/chat/completions"
         content = None
+        resp = None
+
+        for k,v in user_payload.items():
+            if k in reserved_keys:
+                self.log.warning(f"AI 搜题 - {k} 为系统保留字段，已忽略")
+                continue
+            payload[k] = v
 
         for attempt in range(1, max_retries + 1):
             try:
@@ -2156,14 +2176,19 @@ jupiter_fallback=true 时也补翻页轨迹。再答题，最后完课。
                 break
 
             except (OSError, ValueError, KeyError, IndexError, TypeError) as e:
+                api_detail = (
+                    f"，响应体：{resp.text[:300]}" if resp is not None else ""
+                )
                 if attempt < max_retries:
                     wait = attempt * 2
                     self.log.warning(
-                        f"AI 搜题第 {attempt} 次请求失败，{wait}s 后重试：{e}"
+                        f"AI 搜题第 {attempt} 次请求失败，{wait}s 后重试：{e}{api_detail}"
                     )
                     time.sleep(wait)
                 else:
-                    self.log.error(f"AI 搜题请求失败（已重试 {max_retries} 次）：{e}")
+                    self.log.error(
+                        f"AI 搜题请求失败（已重试 {max_retries} 次）：{e}{api_detail}"
+                    )
                     return []
 
         if not content:

--- a/config.example.toml
+++ b/config.example.toml
@@ -129,7 +129,7 @@ debug = false
 [ai]
 # 是否启用 AI 搜题功能（当题库无匹配时，优先采用 AI 搜题解答，AI 答题失败将回退到随机答题的配置）
 enable = true
-# API 基础路径，例如 DeepSeek、硅基流动等 OpenAI 兼容接口路径（/chat/completions）
+# API 基础路径，例如 DeepSeek、硅基流动等 OpenAI 兼容接口路径（本软件会自动补上/chat/completions路径，填写时请注意）
 base_url = "https://opencode.ai/zen/v1"
 # AI 服务的 API Key
 api_key = ""

--- a/config.example.toml
+++ b/config.example.toml
@@ -139,3 +139,6 @@ model = "nemotron-3-ultra-free"
 timeout = 60
 # 请求失败时的最大重试次数
 max_retries = 2
+# 在此新增自定义请求体，使用json格式，写进一行里。本功能可用于自定义模型思考深度、强制json输出等，具体可查询各厂商文档
+# 以智谱为例：custom_body = '{"reasoning_effort": "max", "response_format": {"type": "json_object"}}'
+custom_body = '{"response_format": {"type": "json_object"}}'


### PR DESCRIPTION
如题，添加了自定义AI请求体的功能，便于用户设置思考深度、是否思考、强制json输出等配置方式因厂商而异的参数。并且修改了配置文件里的帮助性注释以及部分表述，以便用户更清晰地理解。

各个厂商的某些配置字段不尽相同，适配起来较为繁琐且可能需要引入复杂的第三方依赖，因此我们可以允许用户自定义请求体，并将强制json输出的设定从硬编码的代码中剥离出来，方便用户使用Opencode等不支持此参数的供应商。

目前，硬编码的请求体参数中只保留了 `messages` 、 `model` 、 `temperature` 这三个，所有openai兼容供应商都支持这仨参数，因此不会有兼容性问题，需要其他更高级的设置（如强制JSON）时，用户可以参考大模型供应商的文档，自行设置自定义请求体。